### PR TITLE
Add API POST & PATCH Support 

### DIFF
--- a/docs/mokkari/schemas/arc.md
+++ b/docs/mokkari/schemas/arc.md
@@ -1,1 +1,2 @@
 :::mokkari.schemas.arc.Arc
+:::mokkari.schemas.arc.ArcPost

--- a/docs/mokkari/schemas/character.md
+++ b/docs/mokkari/schemas/character.md
@@ -1,1 +1,3 @@
 :::mokkari.schemas.character.Character
+:::mokkari.schemas.character.CharacterPost
+:::mokkari.schemas.character.CharacterPostResponse

--- a/docs/mokkari/schemas/creator.md
+++ b/docs/mokkari/schemas/creator.md
@@ -1,1 +1,2 @@
 :::mokkari.schemas.creator.Creator
+:::mokkari.schemas.creator.CreatorPost

--- a/docs/mokkari/schemas/issue.md
+++ b/docs/mokkari/schemas/issue.md
@@ -1,6 +1,10 @@
 :::mokkari.schemas.issue.Credit
+:::mokkari.schemas.issue.CreditPost
+:::mokkari.schemas.issue.CreditPostResponse
 :::mokkari.schemas.issue.BasicSeries
 :::mokkari.schemas.issue.IssueSeries
 :::mokkari.schemas.issue.CommonIssue
 :::mokkari.schemas.issue.BaseIssue
 :::mokkari.schemas.issue.Issue
+:::mokkari.schemas.issue.IssuePost
+:::mokkari.schemas.issue.IssuePostResponse

--- a/docs/mokkari/schemas/publisher.md
+++ b/docs/mokkari/schemas/publisher.md
@@ -1,1 +1,2 @@
 :::mokkari.schemas.publisher.Publisher
+:::mokkari.schemas.publisher.PublisherPost

--- a/docs/mokkari/schemas/series.md
+++ b/docs/mokkari/schemas/series.md
@@ -2,3 +2,5 @@
 :::mokkari.schemas.series.CommonSeries
 :::mokkari.schemas.series.BaseSeries
 :::mokkari.schemas.series.Series
+:::mokkari.schemas.series.SeriesPost
+:::mokkari.schemas.series.SeriesPostResponse

--- a/docs/mokkari/schemas/team.md
+++ b/docs/mokkari/schemas/team.md
@@ -1,1 +1,3 @@
 :::mokkari.schemas.team.Team
+:::mokkari.schemas.team.TeamPost
+:::mokkari.schemas.team.TeamPostResponse

--- a/docs/mokkari/schemas/universe.md
+++ b/docs/mokkari/schemas/universe.md
@@ -1,1 +1,3 @@
 :::mokkari.schemas.universe.Universe
+:::mokkari.schemas.universe.UniversePost
+:::mokkari.schemas.universe.UniversePostResponse

--- a/mokkari/schemas/arc.py
+++ b/mokkari/schemas/arc.py
@@ -34,14 +34,14 @@ class ArcPost(BaseModel):
     """A data model representing an arc to be created.
 
     Attributes:
-        name (str): The name of the arc.
+        name (str, optional): The name of the arc.
         desc (str, optional): The description of the arc.
         image (str, optional): The image URL of the arc.
         cv_id (int, optional): The Comic Vine ID of the arc.
         gcd_id (int, optional): The Grand Comics Database ID of the arc.
     """
 
-    name: str
+    name: str | None = None
     desc: str | None = None
     image: str | None = None
     cv_id: int | None = None

--- a/mokkari/schemas/arc.py
+++ b/mokkari/schemas/arc.py
@@ -5,7 +5,9 @@ This module provides the following classes:
 - Arc
 """
 
-from pydantic import HttpUrl
+__all__ = ["Arc", "ArcPost"]
+
+from pydantic import BaseModel, HttpUrl
 
 from mokkari.schemas.base import BaseResource
 
@@ -26,3 +28,21 @@ class Arc(BaseResource):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class ArcPost(BaseModel):
+    """A data model representing an arc to be created.
+
+    Attributes:
+        name (str): The name of the arc.
+        desc (str, optional): The description of the arc.
+        image (str, optional): The image URL of the arc.
+        cv_id (int, optional): The Comic Vine ID of the arc.
+        gcd_id (int, optional): The Grand Comics Database ID of the arc.
+    """
+
+    name: str
+    desc: str | None = None
+    image: str | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None

--- a/mokkari/schemas/arc.py
+++ b/mokkari/schemas/arc.py
@@ -7,8 +7,9 @@ This module provides the following classes:
 
 __all__ = ["Arc", "ArcPost"]
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import HttpUrl
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 
 

--- a/mokkari/schemas/character.py
+++ b/mokkari/schemas/character.py
@@ -6,7 +6,8 @@ This module provides the following classes:
 - Character
 """
 
-from pydantic import HttpUrl
+__all__ = ["Character", "CharacterPost", "CharacterPostResponse"]
+from pydantic import BaseModel, HttpUrl
 
 from mokkari.schemas.base import BaseResource
 
@@ -35,3 +36,46 @@ class Character(BaseResource):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class CharacterPost(BaseModel):
+    """A data model representing a character to be created.
+
+    Attributes:
+        name (str, optional): The name of the character.
+        alias (list[str], optional): The aliases of the character.
+        desc (str, optional): The description of the character.
+        image (str, optional): The image URL of the character.
+        creators (list[int], optional): The IDs of the creators of the character.
+        teams (list[int], optional): The IDs of the teams the character belongs to.
+        universes (list[int], optional): The IDs of the universes the character is associated with.
+        cv_id (int, optional): The Comic Vine ID of the character.
+        gcd_id (int, optional): The Grand Comics Database ID of the character.
+    """
+
+    name: str | None = None
+    alias: list[str] | None = None
+    desc: str | None = None
+    image: str | None = None
+    creators: list[int] | None = None
+    teams: list[int] | None = None
+    universes: list[int] | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None
+
+
+class CharacterPostResponse(BaseResource, CharacterPost):
+    """A data model representing the response from creating a character.
+
+    Attributes:
+        name (str): The name of the character.
+        alias (list[str], optional): The aliases of the character.
+        desc (str, optional): The description of the character.
+        image (str, optional): The image URL of the character.
+        creators (list[int], optional): The IDs of the creators of the character.
+        teams (list[int], optional): The IDs of the teams the character belongs to.
+        universes (list[int], optional): The IDs of the universes the character is associated with.
+        cv_id (int, optional): The Comic Vine ID of the character.
+        gcd_id (int, optional): The Grand Comics Database ID of the character.
+        resource_url (HttpUrl): The URL of the character resource.
+    """

--- a/mokkari/schemas/character.py
+++ b/mokkari/schemas/character.py
@@ -7,8 +7,9 @@ This module provides the following classes:
 """
 
 __all__ = ["Character", "CharacterPost", "CharacterPostResponse"]
-from pydantic import BaseModel, HttpUrl
+from pydantic import HttpUrl
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 
 

--- a/mokkari/schemas/creator.py
+++ b/mokkari/schemas/creator.py
@@ -5,9 +5,11 @@ This module provides the following classes:
 - Creator
 """
 
+__all__ = ["Creator", "CreatorPost"]
+
 from datetime import date
 
-from pydantic import HttpUrl, PastDate
+from pydantic import BaseModel, HttpUrl, PastDate
 
 from mokkari.schemas.base import BaseResource
 
@@ -34,3 +36,27 @@ class Creator(BaseResource):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class CreatorPost(BaseModel):
+    """A data model representing a creator to be created.
+
+    Attributes:
+        name (str): The name of the creator.
+        birth (PastDate, optional): The birthdate of the creator.
+        death (date, optional): The death date of the creator.
+        desc (str, optional): The description of the creator.
+        image (str, optional): The image URL of the creator.
+        alias (list[str], optional): The aliases of the creator.
+        cv_id (int, optional): The Comic Vine ID of the creator.
+        gcd_id (int, optional): The Grand Comics Database ID of the creator.
+    """
+
+    name: str
+    birth: PastDate | None = None
+    death: date | None = None
+    desc: str | None = None
+    image: str | None = None
+    alias: list[str] | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None

--- a/mokkari/schemas/creator.py
+++ b/mokkari/schemas/creator.py
@@ -42,7 +42,7 @@ class CreatorPost(BaseModel):
     """A data model representing a creator to be created.
 
     Attributes:
-        name (str): The name of the creator.
+        name (str, optional): The name of the creator.
         birth (PastDate, optional): The birthdate of the creator.
         death (date, optional): The death date of the creator.
         desc (str, optional): The description of the creator.
@@ -52,7 +52,7 @@ class CreatorPost(BaseModel):
         gcd_id (int, optional): The Grand Comics Database ID of the creator.
     """
 
-    name: str
+    name: str | None = None
     birth: PastDate | None = None
     death: date | None = None
     desc: str | None = None

--- a/mokkari/schemas/creator.py
+++ b/mokkari/schemas/creator.py
@@ -9,8 +9,9 @@ __all__ = ["Creator", "CreatorPost"]
 
 from datetime import date
 
-from pydantic import BaseModel, HttpUrl, PastDate
+from pydantic import HttpUrl, PastDate
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 
 

--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -4,6 +4,8 @@
 This module provides the following classes:
 
 - Credit
+- CreditPost
+- CreditPostResponse
 - BasicSeries
 - IssueSeries
 - CommonIssue
@@ -18,6 +20,8 @@ __all__ = [
     "BasicSeries",
     "CommonIssue",
     "Credit",
+    "CreditPost",
+    "CreditPostResponse",
     "Issue",
     "IssuePost",
     "IssuePostResponse",
@@ -48,6 +52,35 @@ class Credit(BaseModel):
     id: int
     creator: str
     role: list[GenericItem] = []
+
+
+class CreditPost(BaseModel):
+    """A data model representing a credit to be created.
+
+    Attributes:
+        issue (int): The ID of the issue.
+        creator (int): The ID of the creator.
+        role (list[int]): The IDs of the roles.
+    """
+
+    issue: int
+    creator: int
+    role: list[int]
+
+
+class CreditPostResponse(CreditPost):
+    """A data model representing the response after creating a credit.
+
+    Attributes:
+        id (int): The ID of the credit.
+        issue (int): The ID of the issue.
+        creator (int): The ID of the creator.
+        role (list[int]): The IDs of the roles.
+        modified (datetime): The date and time when the credit was modified.
+    """
+
+    id: int
+    modified: datetime
 
 
 class BasicSeries(BaseModel):

--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -9,7 +9,20 @@ This module provides the following classes:
 - CommonIssue
 - BaseIssue
 - Issue
+- IssuePost
+- IssuePostResponse
 """
+
+__all__ = [
+    "BaseIssue",
+    "BasicSeries",
+    "CommonIssue",
+    "Credit",
+    "Issue",
+    "IssuePost",
+    "IssuePostResponse",
+    "IssueSeries",
+]
 
 from datetime import date, datetime
 from decimal import Decimal
@@ -159,4 +172,91 @@ class Issue(CommonIssue):
     variants: list[Variant] = []
     cv_id: int | None = None
     gcd_id: int | None = None
+    resource_url: HttpUrl
+
+
+class IssuePost(BaseModel):
+    """A data model representing an issue to be created.
+
+    Attributes:
+        series (int, optional): The ID of the series to which the issue belongs.
+        number (str, optional): The number of the issue.
+        alt_number (str, optional): The alternative number of the issue.
+        title (str, optional): The collection title of the issue.
+        name (list[str], optional): The story titles of the issue.
+        cover_date (date, optional): The cover date of the issue.
+        store_date (date, optional): The store date of the issue.
+        price (Decimal, optional): The price of the issue.
+        rating (int, optional): The ID of the rating of the issue.
+        sku (str, optional): The SKU of the issue.
+        isbn (str, optional): The ISBN of the issue.
+        upc (str, optional): The UPC of the issue.
+        page (int, optional): The number of pages in the issue.
+        desc (str, optional): The description of the issue.
+        image (str, optional): The image URL of the issue.
+        arcs (list[int], optional): The IDs of the arcs associated with the issue.
+        characters (list[int], optional): The IDs of the characters featured in the issue.
+        teams (list[int], optional): The IDs of the teams involved in the issue.
+        universes (list[int], optional): The IDs of the universes related to the issue.
+        reprints (list[int], optional): The IDs of the reprints of the issue.
+        cv_id (int, optional): The Comic Vine ID of the issue.
+        gcd_id (int, optional): The Grand Comics Database ID of the issue.
+    """
+
+    series: int | None = None
+    number: str | None = None
+    alt_number: str | None = None
+    title: str | None = None  # Collection Title
+    name: list[str] | None = None
+    cover_date: date | None = None
+    store_date: date | None = None
+    price: Decimal | None = None
+    rating: int | None = None
+    sku: str | None = None
+    isbn: str | None = None
+    upc: str | None = None
+    page: int | None = None
+    desc: str | None = None
+    image: str | None = None
+    arcs: list[int] | None = None
+    characters: list[int] | None = None
+    teams: list[int] | None = None
+    universes: list[int] | None = None
+    reprints: list[int] | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None
+
+
+class IssuePostResponse(IssuePost):
+    """A data model representing the response from creating an issue.
+
+    Attributes:
+        id: The ID of the issue.
+        series (int, optional): The ID of the series to which the issue belongs.
+        number (str, optional): The number of the issue.
+        alt_number (str, optional): The alternative number of the issue.
+        title (str, optional): The collection title of the issue.
+        name (list[str], optional): The story titles of the issue.
+        cover_date (date, optional): The cover date of the issue.
+        store_date (date, optional): The store date of the issue.
+        price (Decimal, optional): The price of the issue.
+        rating (int, optional): The ID of the rating of the issue.
+        sku (str, optional): The SKU of the issue.
+        isbn (str, optional): The ISBN of the issue.
+        upc (str, optional): The UPC of the issue.
+        page (int, optional): The number of pages in the issue.
+        desc (str, optional): The description of the issue.
+        image (str, optional): The image URL of the issue.
+        arcs (list[int], optional): The IDs of the arcs associated with the issue.
+        characters (list[int], optional): The IDs of the characters featured in the issue.
+        teams (list[int], optional): The IDs of the teams involved in the issue.
+        universes (list[int], optional): The IDs of the universes related to the issue.
+        reprints (list[int], optional): The IDs of the reprints of the issue.
+        cv_id (int, optional): The Comic Vine ID of the issue.
+        gcd_id (int, optional): The Grand Comics Database ID of the issue.
+        resource_url (HttpUrl): The URL of the issue resource.
+    """
+
+    # TODO: For some reason the Issue POST & PATCH responses don't include the modified field, should fix that.
+    id: int
     resource_url: HttpUrl

--- a/mokkari/schemas/publisher.py
+++ b/mokkari/schemas/publisher.py
@@ -9,8 +9,9 @@ __all__ = ["Publisher", "PublisherPost"]
 
 from typing import Annotated
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import HttpUrl
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 
 COUNTY_CODE_LENGTH = 2

--- a/mokkari/schemas/publisher.py
+++ b/mokkari/schemas/publisher.py
@@ -53,7 +53,7 @@ class PublisherPost(BaseModel):
     """A data model representing a publisher to be created.
 
     Attributes:
-        name (str): The name of the publisher.
+        name (str, optional): The name of the publisher.
         founded (int, optional): The year the publisher was founded.
         country: str: An ISO 3166-1 2-letter country code. Defaults to 'US'.
         desc (str, optional): The description of the publisher.
@@ -62,7 +62,7 @@ class PublisherPost(BaseModel):
         gcd_id (int, optional): The Grand Comics Database ID of the publisher.
     """
 
-    name: str
+    name: str | None = None
     founded: int | None = None
     country: Annotated[str, ensure_country_code_length] = "US"
     desc: str | None = None

--- a/mokkari/schemas/publisher.py
+++ b/mokkari/schemas/publisher.py
@@ -5,9 +5,11 @@ This module provides the following classes:
 - Publisher
 """
 
+__all__ = ["Publisher", "PublisherPost"]
+
 from typing import Annotated
 
-from pydantic import HttpUrl
+from pydantic import BaseModel, HttpUrl
 
 from mokkari.schemas.base import BaseResource
 
@@ -45,3 +47,25 @@ class Publisher(BaseResource):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class PublisherPost(BaseModel):
+    """A data model representing a publisher to be created.
+
+    Attributes:
+        name (str): The name of the publisher.
+        founded (int, optional): The year the publisher was founded.
+        country: str: An ISO 3166-1 2-letter country code. Defaults to 'US'.
+        desc (str, optional): The description of the publisher.
+        image (str, optional): The image URL of the publisher.
+        cv_id (int, optional): The Comic Vine ID of the publisher.
+        gcd_id (int, optional): The Grand Comics Database ID of the publisher.
+    """
+
+    name: str
+    founded: int | None = None
+    country: Annotated[str, ensure_country_code_length] = "US"
+    desc: str | None = None
+    image: str | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None

--- a/mokkari/schemas/series.py
+++ b/mokkari/schemas/series.py
@@ -9,11 +9,14 @@ This module provides the following classes:
 - Series
 """
 
+__all__ = ["AssociatedSeries", "BaseSeries", "CommonSeries", "Series"]
+
 from datetime import datetime
 
 from pydantic import Field, HttpUrl
 
 from mokkari.schemas import BaseModel
+from mokkari.schemas.base import BaseResource
 from mokkari.schemas.generic import GenericItem
 
 
@@ -89,3 +92,62 @@ class Series(CommonSeries):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class SeriesPost(BaseModel):
+    """A data model representing a series to be created.
+
+    Attributes:
+        name (str, optional): The name of the series.
+        sort_name (str, optional): The name used for sorting the series.
+        volume (int, optional): The volume number of the series.
+        series_type (int, optional): The ID of the series type.
+        status (int, optional): The ID of the series status.
+        publisher (int, optional): The ID of the publisher of the series.
+        imprint (int, optional): The ID of the imprint of the series.
+        year_began (int, optional): The year the series began.
+        year_end (int, optional): The year the series ended.
+        desc (str, optional): The description of the series.
+        genres (list[int], optional): The IDs of the genres associated with the series.
+        associated (list[int], optional): The IDs of the associated series.
+        cv_id (int, optional): The Comic Vine ID of the series.
+        gcd_id (int, optional): The Grand Comics Database ID of the series.
+    """
+
+    name: str | None = None
+    sort_name: str | None = None
+    volume: int | None = None
+    series_type: int | None = None
+    status: int | None = None
+    publisher: int | None = None
+    imprint: int | None = None
+    year_began: int | None = None
+    year_end: int | None = None
+    desc: str | None = None
+    genres: list[int] | None = None
+    associated: list[int] | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None
+
+
+class SeriesPostResponse(BaseResource, SeriesPost):
+    """A data model representing the response from creating a series.
+
+    Attributes:
+        id (int): The unique identifier of the series.
+        name (str, optional): The name of the series.
+        sort_name (str, optional): The name used for sorting the series.
+        volume (int, optional): The volume number of the series.
+        series_type (int, optional): The ID of the series type.
+        status (int, optional): The ID of the series status.
+        publisher (int, optional): The ID of the publisher of the series.
+        imprint (int, optional): The ID of the imprint of the series.
+        year_began (int, optional): The year the series began.
+        year_end (int, optional): The year the series ended.
+        desc (str, optional): The description of the series.
+        genres (list[int], optional): The IDs of the genres associated with the series.
+        associated (list[int], optional): The IDs of the associated series.
+        cv_id (int, optional): The Comic Vine ID of the series.
+        gcd_id (int, optional): The Grand Comics Database ID of the series.
+        resource_url (HttpUrl): The URL of the series resource.
+    """

--- a/mokkari/schemas/series.py
+++ b/mokkari/schemas/series.py
@@ -7,9 +7,18 @@ This module provides the following classes:
 - CommonSeries
 - BaseSeries
 - Series
+- SeriesPost
+- SeriesPostResponse
 """
 
-__all__ = ["AssociatedSeries", "BaseSeries", "CommonSeries", "Series"]
+__all__ = [
+    "AssociatedSeries",
+    "BaseSeries",
+    "CommonSeries",
+    "Series",
+    "SeriesPost",
+    "SeriesPostResponse",
+]
 
 from datetime import datetime
 

--- a/mokkari/schemas/team.py
+++ b/mokkari/schemas/team.py
@@ -6,7 +6,8 @@ This module provides the following classes:
 - Team
 """
 
-from pydantic import HttpUrl
+__all__ = ["Team", "TeamPost", "TeamPostResponse"]
+from pydantic import BaseModel, HttpUrl
 
 from mokkari.schemas.base import BaseResource
 
@@ -31,3 +32,41 @@ class Team(BaseResource):
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class TeamPost(BaseModel):
+    """A data model representing a team to be created.
+
+    Attributes:
+        name (str, optional): The name of the team.
+        desc (str, optional): The description of the team.
+        image (str, optional): The image URL of the team.
+        creators (list[int], optional): The IDs of the creators of the team.
+        universes (list[int], optional): The IDs of the universes the team is associated with.
+        cv_id (int, optional): The Comic Vine ID of the team.
+        gcd_id (int, optional): The Grand Comics Database ID of the team.
+    """
+
+    name: str | None = None
+    desc: str | None = None
+    image: str | None = None
+    creators: list[int] | None = None
+    universes: list[int] | None = None
+    cv_id: int | None = None
+    gcd_id: int | None = None
+
+
+class TeamPostResponse(BaseResource, TeamPost):
+    """A data model representing the response from creating a team.
+
+    Attributes:
+        id: (int) The ID of the team.
+        name (str): The name of the team.
+        desc (str, optional): The description of the team.
+        image (str, optional): The image URL of the team.
+        creators (list[int], optional): The IDs of the creators of the team.
+        universes (list[int], optional): The IDs of the universes the team is associated with.
+        cv_id (int, optional): The Comic Vine ID of the team.
+        gcd_id (int, optional): The Grand Comics Database ID of the team.
+        resource_url (HttpUrl): The URL of the team resource.
+    """

--- a/mokkari/schemas/team.py
+++ b/mokkari/schemas/team.py
@@ -7,8 +7,9 @@ This module provides the following classes:
 """
 
 __all__ = ["Team", "TeamPost", "TeamPostResponse"]
-from pydantic import BaseModel, HttpUrl
+from pydantic import HttpUrl
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 
 

--- a/mokkari/schemas/team.py
+++ b/mokkari/schemas/team.py
@@ -4,6 +4,8 @@
 This module provides the following classes:
 
 - Team
+- TeamPost
+- TeamPostResponse
 """
 
 __all__ = ["Team", "TeamPost", "TeamPostResponse"]

--- a/mokkari/schemas/universe.py
+++ b/mokkari/schemas/universe.py
@@ -7,8 +7,9 @@ This module provides the following classes:
 
 __all__ = ["Universe", "UniversePost", "UniversePostResponse"]
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import HttpUrl
 
+from mokkari.schemas import BaseModel
 from mokkari.schemas.base import BaseResource
 from mokkari.schemas.generic import GenericItem
 

--- a/mokkari/schemas/universe.py
+++ b/mokkari/schemas/universe.py
@@ -5,7 +5,9 @@ This module provides the following classes:
 - Universe
 """
 
-from pydantic import HttpUrl
+__all__ = ["Universe", "UniversePost", "UniversePostResponse"]
+
+from pydantic import BaseModel, HttpUrl
 
 from mokkari.schemas.base import BaseResource
 from mokkari.schemas.generic import GenericItem
@@ -29,3 +31,37 @@ class Universe(BaseResource):
     image: HttpUrl | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl
+
+
+class UniversePost(BaseModel):
+    """A data model representing a universe to be created.
+
+    Attributes:
+        publisher (int, optional): The ID of the publisher of the universe.
+        name (str, optional): The name of the universe.
+        designation (str, optional): The designation of the universe.
+        desc (str, optional): The description of the universe.
+        image (str, optional): The image URL of the universe.
+        gcd_id (int, optional): The Grand Comics Database ID of the universe.
+    """
+
+    publisher: int | None = None
+    name: str | None = None
+    designation: str | None = None
+    desc: str | None = None
+    gcd_id: int | None = None
+    image: str | None = None
+
+
+class UniversePostResponse(BaseResource, UniversePost):
+    """A data model representing the response from creating a universe.
+
+    Attributes:
+        publisher (int, optional): The ID of the publisher of the universe.
+        name (str, optional): The name of the universe.
+        designation (str, optional): The designation of the universe.
+        desc (str, optional): The description of the universe.
+        image (str, optional): The image URL of the universe.
+        gcd_id (int, optional): The Grand Comics Database ID of the universe.
+        resource_url (HttpUrl): The URL of the universe resource.
+    """

--- a/mokkari/schemas/universe.py
+++ b/mokkari/schemas/universe.py
@@ -3,6 +3,8 @@
 This module provides the following classes:
 
 - Universe
+- UniversePost
+- UniversePostResponse
 """
 
 __all__ = ["Universe", "UniversePost", "UniversePostResponse"]

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -22,6 +22,7 @@ from pydantic import TypeAdapter, ValidationError
 from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
 
 from mokkari import __version__, exceptions, sqlite_cache
+from mokkari.exceptions import ApiError
 from mokkari.schemas.arc import Arc, ArcPost
 from mokkari.schemas.base import BaseResource
 from mokkari.schemas.character import Character, CharacterPost, CharacterPostResponse
@@ -188,7 +189,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["creator"], data)
+        try:
+            resp = self._send("POST", ["creator"], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Creator)
         try:
             result = adaptor.validate_python(resp)
@@ -209,7 +214,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["creator", _id], data)
+        try:
+            resp = self._send("PATCH", ["creator", _id], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Creator)
         try:
             result = adaptor.validate_python(resp)
@@ -273,7 +282,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["character"], data)
+        try:
+            resp = self._send("POST", ["character"], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(CharacterPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -296,7 +309,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["character", _id], data)
+        try:
+            resp = self._send("PATCH", ["character", _id], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(CharacterPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -378,7 +395,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["publisher"], data)
+        try:
+            resp = self._send("POST", ["publisher"], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Publisher)
         try:
             result = adaptor.validate_python(resp)
@@ -399,7 +420,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["publisher", id_], data)
+        try:
+            resp = self._send("PATCH", ["publisher", id_], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Publisher)
         try:
             result = adaptor.validate_python(resp)
@@ -462,7 +487,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["team"], data)
+        try:
+            resp = self._send("POST", ["team"], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(TeamPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -483,7 +512,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["team", id_], data)
+        try:
+            resp = self._send("PATCH", ["team", id_], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(TeamPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -566,7 +599,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["arc"], data)
+        try:
+            resp = self._send("POST", ["arc"], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Arc)
         try:
             result = adaptor.validate_python(resp)
@@ -587,7 +624,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["arc", id_], data)
+        try:
+            resp = self._send("PATCH", ["arc", id_], data)
+        except exceptions.ApiError as error:
+            raise exceptions.ApiError(error) from error
+
         adaptor = TypeAdapter(Arc)
         try:
             result = adaptor.validate_python(resp)
@@ -669,7 +710,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["series"], data)
+        try:
+            resp = self._send("POST", ["series"], data)
+        except ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(SeriesPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -690,7 +735,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["series", id_], data)
+        try:
+            resp = self._send("PATCH", ["series", id_], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(SeriesPostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -774,7 +823,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["issue"], data)
+        try:
+            resp = self._send("POST", ["issue"], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(IssuePostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -795,7 +848,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["issue", id_], data)
+        try:
+            resp = self._send("PATCH", ["issue", id_], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(IssuePostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -837,7 +894,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["credit"], data)
+        try:
+            resp = self._send("POST", ["credit"], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(list[CreditPostResponse])
         try:
             result = adaptor.validate_python(resp)
@@ -899,7 +960,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("POST", ["universe"], data)
+        try:
+            resp = self._send("POST", ["universe"], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(UniversePostResponse)
         try:
             result = adaptor.validate_python(resp)
@@ -922,7 +987,11 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._send("PATCH", ["universe", id_], data)
+        try:
+            resp = self._send("PATCH", ["universe", id_], data)
+        except exceptions.ApiError as err:
+            raise exceptions.ApiError(err) from err
+
         adaptor = TypeAdapter(UniversePostResponse)
         try:
             result = adaptor.validate_python(resp)

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -30,14 +30,14 @@ from mokkari.schemas.imprint import Imprint
 from mokkari.schemas.issue import BaseIssue, Issue
 from mokkari.schemas.publisher import Publisher, PublisherPost
 from mokkari.schemas.series import BaseSeries, Series
-from mokkari.schemas.team import Team
+from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
 from mokkari.schemas.universe import Universe
 
 METRON_MINUTE_RATE_LIMIT = 30
 METRON_URL = "https://metron.cloud/api/{}/"
 LOCAL_URL = "http://127.0.0.1:8000/api/{}/"
 
-T = TypeVar("T", ArcPost, CharacterPost, CreatorPost, PublisherPost)
+T = TypeVar("T", ArcPost, CharacterPost, CreatorPost, PublisherPost, TeamPost)
 
 
 def rate_mapping(*args: any, **kwargs: any) -> tuple[str, int]:  # NOQA: ARG001
@@ -425,6 +425,47 @@ class Session:
         """
         resp = self._get(["team", _id])
         adaptor = TypeAdapter(Team)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def team_post(self: Session, data: TeamPost) -> TeamPostResponse:
+        """Create a new team.
+
+        Args:
+            data: TeamPost object with the team data.
+
+        Returns:
+            A TeamPostResponse object containing information about the created team.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("POST", ["team"], data)
+        adaptor = TypeAdapter(TeamPostResponse)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def team_patch(self: Session, id_: int, data: TeamPost) -> TeamPostResponse:
+        """Update an existing team.
+
+        Args:
+            id_: The ID of the team to update.
+            data: TeamPost object with the updated team data.
+
+        Returns:
+            A TeamPostResponse object containing information about the updated team.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["team", id_], data)
+        adaptor = TypeAdapter(TeamPostResponse)
         try:
             result = adaptor.validate_python(resp)
         except ValidationError as error:

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -177,6 +177,27 @@ class Session:
             raise exceptions.ApiError(error) from error
         return result
 
+    def creator_patch(self: Session, _id: int, data: CreatorPost) -> Creator:
+        """Update an existing creator.
+
+        Args:
+            _id: The ID of the creator to update.
+            data: CreatorPost object with the updated creator data.
+
+        Returns:
+            A Creator object containing information about the updated creator.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["creator", _id], data)
+        adaptor = TypeAdapter(Creator)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
     def creators_list(
         self: Session, params: dict[str, str | int] | None = None
     ) -> list[BaseResource]:

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -27,7 +27,7 @@ from mokkari.schemas.character import Character, CharacterPost, CharacterPostRes
 from mokkari.schemas.creator import Creator, CreatorPost
 from mokkari.schemas.generic import GenericItem
 from mokkari.schemas.imprint import Imprint
-from mokkari.schemas.issue import BaseIssue, Issue
+from mokkari.schemas.issue import BaseIssue, Issue, IssuePost, IssuePostResponse
 from mokkari.schemas.publisher import Publisher, PublisherPost
 from mokkari.schemas.series import BaseSeries, Series, SeriesPost, SeriesPostResponse
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
@@ -42,6 +42,7 @@ T = TypeVar(
     ArcPost,
     CharacterPost,
     CreatorPost,
+    IssuePost,
     PublisherPost,
     SeriesPost,
     TeamPost,
@@ -746,6 +747,47 @@ class Session:
         """
         resp = self._get(["issue", _id])
         adaptor = TypeAdapter(Issue)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def issue_post(self: Session, data: IssuePost) -> IssuePostResponse:
+        """Create a new issue.
+
+        Args:
+            data: IssuePost object with the issue data.
+
+        Returns:
+            An IssuePostResponse object containing information about the created issue.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("POST", ["issue"], data)
+        adaptor = TypeAdapter(IssuePostResponse)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def issue_patch(self: Session, id_: int, data: IssuePost) -> IssuePostResponse:
+        """Update an existing issue.
+
+        Args:
+            id_: The ID of the issue to update.
+            data: IssuePost object with the updated issue data.
+
+        Returns:
+            An IssuePostResponse object containing information about the updated issue.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["issue", id_], data)
+        adaptor = TypeAdapter(IssuePostResponse)
         try:
             result = adaptor.validate_python(resp)
         except ValidationError as error:

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -21,7 +21,6 @@ from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-# Alias these modules to prevent namespace collision with methods.
 from mokkari import __version__, exceptions, sqlite_cache
 from mokkari.schemas.arc import Arc
 from mokkari.schemas.base import BaseResource
@@ -79,7 +78,7 @@ class Session:
         self.api_url = LOCAL_URL if dev_mode else METRON_URL
         self.cache = cache
 
-    def _call(
+    def _get(
         self: Session,
         endpoint: list[str | int],
         params: dict[str, str | int] | None = None,
@@ -132,7 +131,7 @@ class Session:
         Raises:
             ValidationError: If there is an error validating the response data.
         """
-        resp = self._call(["creator", _id])
+        resp = self._get(["creator", _id])
         adaptor = TypeAdapter(Creator)
         try:
             result = adaptor.validate_python(resp)
@@ -176,7 +175,7 @@ class Session:
             ApiError: If there is an error in the API response data validation.
 
         """
-        resp = self._call(["character", _id])
+        resp = self._get(["character", _id])
         adaptor = TypeAdapter(Character)
         try:
             result = adaptor.validate_python(resp)
@@ -238,7 +237,7 @@ class Session:
             A Publisher object containing information about the specified publisher.
 
         """
-        resp = self._call(["publisher", _id])
+        resp = self._get(["publisher", _id])
         adaptor = TypeAdapter(Publisher)
         try:
             result = adaptor.validate_python(resp)
@@ -281,7 +280,7 @@ class Session:
         Raises:
             ApiError: If there is an error in the API response data validation.
         """
-        resp = self._call(["team", _id])
+        resp = self._get(["team", _id])
         adaptor = TypeAdapter(Team)
         try:
             result = adaptor.validate_python(resp)
@@ -344,7 +343,7 @@ class Session:
         Raises:
             ApiError: If there is an error in the API response data validation.
         """
-        resp = self._call(["arc", _id])
+        resp = self._get(["arc", _id])
         adaptor = TypeAdapter(Arc)
         try:
             result = adaptor.validate_python(resp)
@@ -406,7 +405,7 @@ class Session:
         Raises:
             ApiError: If there is an error in the API response data validation.
         """
-        resp = self._call(["series", _id])
+        resp = self._get(["series", _id])
         adaptor = TypeAdapter(Series)
         try:
             result = adaptor.validate_python(resp)
@@ -470,7 +469,7 @@ class Session:
         Raises:
             ApiError: If there is an error in the API response data validation.
         """
-        resp = self._call(["issue", _id])
+        resp = self._get(["issue", _id])
         adaptor = TypeAdapter(Issue)
         try:
             result = adaptor.validate_python(resp)
@@ -534,7 +533,7 @@ class Session:
         Raises:
             ApiError: If there is an error in the API response data validation.
         """
-        resp = self._call(["universe", _id])
+        resp = self._get(["universe", _id])
         adaptor = TypeAdapter(Universe)
         try:
             result = adaptor.validate_python(resp)
@@ -576,7 +575,7 @@ class Session:
         Raises:
             ApiError: If there is an error during the API call or validation.
         """
-        resp = self._call(["imprint", _id])
+        resp = self._get(["imprint", _id])
         adaptor = TypeAdapter(Imprint)
         try:
             result = adaptor.validate_python(resp)
@@ -623,7 +622,7 @@ class Session:
         if params is None:
             params = {}
 
-        result = self._call(endpoint, params=params)
+        result = self._get(endpoint, params=params)
         if result["next"]:
             result = self._retrieve_all_results(result)
         return result

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -346,6 +346,27 @@ class Session:
             raise exceptions.ApiError(err) from err
         return result
 
+    def publisher_patch(self: Session, id_: int, data: PublisherPost) -> Publisher:
+        """Update an existing publisher.
+
+        Args:
+            id_: The ID of the publisher to update.
+            data: PublisherPost object with the updated publisher data.
+
+        Returns:
+            A Publisher object containing information about the updated publisher.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["publisher", id_], data)
+        adaptor = TypeAdapter(Publisher)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as err:
+            raise exceptions.ApiError(err) from err
+        return result
+
     def publishers_list(
         self: Session, params: dict[str, str | int] | None = None
     ) -> list[BaseResource]:
@@ -465,6 +486,27 @@ class Session:
             ApiError: If there is an error during the API call or validation.
         """
         resp = self._send("POST", ["arc"], data)
+        adaptor = TypeAdapter(Arc)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as err:
+            raise exceptions.ApiError(err) from err
+        return result
+
+    def arc_patch(self: Session, id_: int, data: ArcPost) -> Arc:
+        """Update an existing arc.
+
+        Args:
+            id_: The ID of the arc to update.
+            data: ArcPost object with the updated arc data.
+
+        Returns:
+            An Arc object containing information about the updated arc.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["arc", id_], data)
         adaptor = TypeAdapter(Arc)
         try:
             result = adaptor.validate_python(resp)

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -180,6 +180,8 @@ class Session:
     def creator_post(self: Session, data: CreatorPost) -> Creator:
         """Create a new creator.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: CreatorPost object with the creator data.
 
@@ -203,6 +205,8 @@ class Session:
 
     def creator_patch(self: Session, _id: int, data: CreatorPost) -> Creator:
         """Update an existing creator.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             _id: The ID of the creator to update.
@@ -273,6 +277,8 @@ class Session:
     def character_post(self: Session, data: CharacterPost) -> CharacterPostResponse:
         """Create a new character.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: CharacterPost object with the character data.
 
@@ -298,6 +304,8 @@ class Session:
         self: Session, _id: int, data: CharacterPost
     ) -> CharacterPostResponse:
         """Update an existing character.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             _id: The ID of the character to update.
@@ -386,6 +394,8 @@ class Session:
     def publisher_post(self: Session, data: PublisherPost) -> Publisher:
         """Create a new publisher.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: PublisherPost object with the publisher data.
 
@@ -409,6 +419,8 @@ class Session:
 
     def publisher_patch(self: Session, id_: int, data: PublisherPost) -> Publisher:
         """Update an existing publisher.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the publisher to update.
@@ -478,6 +490,8 @@ class Session:
     def team_post(self: Session, data: TeamPost) -> TeamPostResponse:
         """Create a new team.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: TeamPost object with the team data.
 
@@ -501,6 +515,8 @@ class Session:
 
     def team_patch(self: Session, id_: int, data: TeamPost) -> TeamPostResponse:
         """Update an existing team.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the team to update.
@@ -590,6 +606,8 @@ class Session:
     def arc_post(self: Session, data: ArcPost) -> Arc:
         """Create a new arc.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: ArcPost object with the arc data.
 
@@ -613,6 +631,8 @@ class Session:
 
     def arc_patch(self: Session, id_: int, data: ArcPost) -> Arc:
         """Update an existing arc.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the arc to update.
@@ -701,6 +721,8 @@ class Session:
     def series_post(self: Session, data: SeriesPost) -> SeriesPostResponse:
         """Create a new series.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: SeriesPost object with the series data.
 
@@ -724,6 +746,8 @@ class Session:
 
     def series_patch(self: Session, id_: int, data: SeriesPost) -> SeriesPostResponse:
         """Update an existing series.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the series to update.
@@ -814,6 +838,8 @@ class Session:
     def issue_post(self: Session, data: IssuePost) -> IssuePostResponse:
         """Create a new issue.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: IssuePost object with the issue data.
 
@@ -837,6 +863,8 @@ class Session:
 
     def issue_patch(self: Session, id_: int, data: IssuePost) -> IssuePostResponse:
         """Update an existing issue.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the issue to update.
@@ -884,6 +912,8 @@ class Session:
 
     def credits_post(self: Session, data: list[CreditPost]) -> CreditPostResponse:
         """Create new credits.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             data: A list of CreditPost objects with the credit data.
@@ -951,6 +981,8 @@ class Session:
     def universe_post(self: Session, data: UniversePost) -> UniversePostResponse:
         """Create a new universe.
 
+        Note: This function only works for users with Admin permissions at Metron.
+
         Args:
             data: UniversePost object with the universe data.
 
@@ -976,6 +1008,8 @@ class Session:
         self: Session, id_: int, data: UniversePost
     ) -> UniversePostResponse:
         """Update an existing universe.
+
+        Note: This function only works for users with Admin permissions at Metron.
 
         Args:
             id_: The ID of the universe to update.

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -93,8 +93,7 @@ class Session:
         self.passwd = passwd
         self.header = {
             "User-Agent": f"{f'{user_agent} ' if user_agent is not None else ''}"
-            f"Mokkari/{__version__} ({platform.system()}; {platform.release()})",
-            "Content-Type": "application/json",
+            f"Mokkari/{__version__} ({platform.system()}; {platform.release()})"
         }
         self.api_url = LOCAL_URL if dev_mode else METRON_URL
         self.cache = cache
@@ -1062,10 +1061,12 @@ class Session:
             params = {}
 
         files = None
+        header = self.header
         if isinstance(data, list):
             lst = []
             lst.extend(item.model_dump() for item in data)
             data_dict = json.dumps(lst)
+            header = self.header["Content-Type"] = "application/json"
         else:
             data_dict = data.model_dump() if data is not None else None
             if data_dict is not None and "image" in data_dict:  # NOQA: SIM102
@@ -1080,7 +1081,7 @@ class Session:
                 params=params,
                 timeout=2.5,
                 auth=(self.username, self.passwd),
-                headers=self.header,
+                headers=header,
                 data=data_dict,
                 files=files,
             )

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -31,13 +31,15 @@ from mokkari.schemas.issue import BaseIssue, Issue
 from mokkari.schemas.publisher import Publisher, PublisherPost
 from mokkari.schemas.series import BaseSeries, Series
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
-from mokkari.schemas.universe import Universe
+from mokkari.schemas.universe import Universe, UniversePost, UniversePostResponse
 
 METRON_MINUTE_RATE_LIMIT = 30
 METRON_URL = "https://metron.cloud/api/{}/"
 LOCAL_URL = "http://127.0.0.1:8000/api/{}/"
 
-T = TypeVar("T", ArcPost, CharacterPost, CreatorPost, PublisherPost, TeamPost)
+T = TypeVar(
+    "T", ArcPost, CharacterPost, CreatorPost, PublisherPost, TeamPost, UniversePost
+)
 
 
 def rate_mapping(*args: any, **kwargs: any) -> tuple[str, int]:  # NOQA: ARG001
@@ -760,6 +762,49 @@ class Session:
         """
         resp = self._get(["universe", _id])
         adaptor = TypeAdapter(Universe)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def universe_post(self: Session, data: UniversePost) -> UniversePostResponse:
+        """Create a new universe.
+
+        Args:
+            data: UniversePost object with the universe data.
+
+        Returns:
+            A UniversePostResponse object containing information about the created universe.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("POST", ["universe"], data)
+        adaptor = TypeAdapter(UniversePostResponse)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as error:
+            raise exceptions.ApiError(error) from error
+        return result
+
+    def universe_patch(
+        self: Session, id_: int, data: UniversePost
+    ) -> UniversePostResponse:
+        """Update an existing universe.
+
+        Args:
+            id_: The ID of the universe to update.
+            data: UniversePost object with the updated universe data.
+
+        Returns:
+            A UniversePostResponse object containing information about the updated universe.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["universe", id_], data)
+        adaptor = TypeAdapter(UniversePostResponse)
         try:
             result = adaptor.validate_python(resp)
         except ValidationError as error:

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -29,7 +29,7 @@ from mokkari.schemas.generic import GenericItem
 from mokkari.schemas.imprint import Imprint
 from mokkari.schemas.issue import BaseIssue, Issue
 from mokkari.schemas.publisher import Publisher, PublisherPost
-from mokkari.schemas.series import BaseSeries, Series
+from mokkari.schemas.series import BaseSeries, Series, SeriesPost, SeriesPostResponse
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
 from mokkari.schemas.universe import Universe, UniversePost, UniversePostResponse
 
@@ -38,7 +38,14 @@ METRON_URL = "https://metron.cloud/api/{}/"
 LOCAL_URL = "http://127.0.0.1:8000/api/{}/"
 
 T = TypeVar(
-    "T", ArcPost, CharacterPost, CreatorPost, PublisherPost, TeamPost, UniversePost
+    "T",
+    ArcPost,
+    CharacterPost,
+    CreatorPost,
+    PublisherPost,
+    SeriesPost,
+    TeamPost,
+    UniversePost,
 )
 
 
@@ -634,6 +641,47 @@ class Session:
         """
         resp = self._get(["series", _id])
         adaptor = TypeAdapter(Series)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as err:
+            raise exceptions.ApiError(err) from err
+        return result
+
+    def series_post(self: Session, data: SeriesPost) -> SeriesPostResponse:
+        """Create a new series.
+
+        Args:
+            data: SeriesPost object with the series data.
+
+        Returns:
+            A SeriesPostResponse object containing information about the created series.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("POST", ["series"], data)
+        adaptor = TypeAdapter(SeriesPostResponse)
+        try:
+            result = adaptor.validate_python(resp)
+        except ValidationError as err:
+            raise exceptions.ApiError(err) from err
+        return result
+
+    def series_patch(self: Session, id_: int, data: SeriesPost) -> SeriesPostResponse:
+        """Update an existing series.
+
+        Args:
+            id_: The ID of the series to update.
+            data: SeriesPost object with the updated series data.
+
+        Returns:
+            A SeriesPostResponse object containing information about the updated series.
+
+        Raises:
+            ApiError: If there is an error during the API call or validation.
+        """
+        resp = self._send("PATCH", ["series", id_], data)
+        adaptor = TypeAdapter(SeriesPostResponse)
         try:
             result = adaptor.validate_python(resp)
         except ValidationError as err:


### PR DESCRIPTION
This PR add functions for POST & PATCH API calls to Metron.

To make the code more usable I've removed the api retry code, but may add it back if it proves to be a problem.

Note: To use the functions the user must have permissions for these methods which are currently restricted to the site admins.