### PR TITLE
Raise `RateLimitError` on HTTP 429 error codes

### DIFF
--- a/mokkari/exceptions.py
+++ b/mokkari/exceptions.py
@@ -18,6 +18,14 @@ class ApiError(Exception):
         Exception.__init__(self, *args, **kwargs)
 
 
+class RateLimitError(Exception):
+    """Class for any rate limit errors."""
+
+    def __init__(self: ApiError, *args, **kwargs: dict[str, any]) -> None:
+        """Initialize an ApiError."""
+        Exception.__init__(self, *args, **kwargs)
+
+
 class AuthenticationError(Exception):
     """Class for any authentication errors."""
 

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -589,7 +589,7 @@ class Session:
         return data
 
     @decorator(rate_mapping)
-    def _request_data(
+    def _request_data(  # noqa: C901
         self,
         method: str,
         url: str,
@@ -646,6 +646,10 @@ class Session:
         ) as e:
             msg = f"Connection error: {e!r}"
             raise exceptions.ApiError(msg) from e
+
+        if response.status_code == requests.codes.too_many:
+            msg = f"Metron API Rate Limit exceeded, need to wait for {format_time(response.headers['Retry-After'])}."
+            raise exceptions.RateLimitError(msg)
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
This PR simply raises a new exception (`RateLimitError`) on a request with HTTP 429 status code.  The exceptions message presents the wait time in a human readable format.