### PR TITLE
Improve API rate limiting

### DIFF
--- a/mokkari/exceptions.py
+++ b/mokkari/exceptions.py
@@ -2,9 +2,10 @@
 
 This module provides the following classes:
 
-- ApiError
-- AuthenticationError
-- CacheError
+- ApiError: General API errors, authentication failures, or network issues
+- RateLimitError: Raised when API rate limits are exceeded
+- AuthenticationError: Missing or invalid authentication credentials
+- CacheError: Errors related to cache operations
 """
 
 from __future__ import annotations
@@ -19,10 +20,38 @@ class ApiError(Exception):
 
 
 class RateLimitError(Exception):
-    """Class for any rate limit errors."""
+    """Exception raised when API rate limits are exceeded.
 
-    def __init__(self: ApiError, *args, **kwargs: dict[str, any]) -> None:
-        """Initialize an ApiError."""
+    This exception is raised when either the per-minute (30 requests) or per-day
+    (10,000 requests) rate limit is exceeded. The exception message includes:
+    - Which rate limit was exceeded (minute or day)
+    - The specific limit value
+    - Human-readable wait time before the next request can be made
+
+    The rate limiting is enforced locally before making API requests, preventing
+    unnecessary HTTP calls that would fail on the server side.
+
+    Note:
+        Applications should catch this exception and implement appropriate retry
+        logic or inform users about the rate limit. See the Session class
+        documentation for examples of handling this exception.
+
+    Examples:
+        >>> from mokkari import Session
+        >>> from mokkari.exceptions import RateLimitError
+        >>> import time
+        >>> session = Session("username", "password")
+        >>> try:
+        ...     issue = session.issue(1)
+        ... except RateLimitError as e:
+        ...     # Error message format:
+        ...     # "Rate limit exceeded: You have reached the 30 requests per minute limit.
+        ...     #  Please wait 1 minute, 30 seconds before making another request."
+        ...     print(f"Rate limited: {e}")
+    """
+
+    def __init__(self: RateLimitError, *args, **kwargs: dict[str, any]) -> None:
+        """Initialize a RateLimitError."""
         Exception.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
This PR Improve API rate limiting with better error messages and documentation

**Rate Limiting Improvements:**
- Removed decorator-based approach in favor of direct limiter usage for better control
- Changed from `raise_when_fail=False` to `raise_when_fail=True` with `max_delay=0` to provide immediate feedback
- Enhanced error messages to clearly indicate which limit was exceeded (minute vs day)
- Added human-readable wait times (e.g., "2 hours, 30 minutes" instead of raw seconds)
- Improved delay extraction from both BucketFullException and LimiterDelayException

**Code Changes:**
- mokkari/session.py:
  - Removed `rate_mapping()` function (no longer needed)
  - Updated `_request_data()` to catch rate limit exceptions before HTTP requests
  - Added comprehensive delay parsing with multiple fallback strategies
  - Updated imports to include BucketFullException and LimiterDelayException

- mokkari/exceptions.py:
  - Fixed type annotation in RateLimitError.__init__ (ApiError -> RateLimitError)
  - Added comprehensive docstring with usage examples
  - Updated module docstring to document all exception types

**Documentation:**
- Added prominent warning in Session class about RateLimitError behavior
- Included two practical examples: basic error handling and exponential backoff retry
- Documented that rate limiting prevents HTTP requests (doesn't just report errors)
- Added detailed RateLimitError documentation with message format examples

**Tests:**
- Added 6 comprehensive rate limiting test:
  1. test_rate_limit_minute_exceeded - Verifies minute limit error messages
  2. test_rate_limit_day_exceeded - Verifies daily limit error messages
  3. test_rate_limit_blocks_request - Confirms HTTP requests are blocked
  4. test_rate_limit_bucket_full_exception - Tests BucketFullException handling
  5. test_rate_limit_format_time_hours - Tests time formatting for longer delays
  6. test_rate_limit_allows_successful_request - Verifies normal operation