### PR TITLE
Add retry_after attribute to RateLimitError

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,38 @@ for i in this_week:
 print(asm_68.desc)
 ```
 
+## Rate Limiting
+
+The API has rate limits of 30 requests per minute and 10,000 requests per day.
+Mokkari automatically enforces these limits locally to prevent unnecessary API
+calls. When a rate limit is exceeded, a `RateLimitError` is raised.
+
+### Handling Rate Limits
+
+The `RateLimitError` includes a `retry_after` attribute that tells you exactly
+how many seconds to wait before making another request:
+
+```python
+import mokkari
+from mokkari.exceptions import RateLimitError
+import time
+
+m = mokkari.api(username, password)
+
+try:
+    issue = m.issue(31660)
+except RateLimitError as e:
+    # Display user-friendly message
+    print(f"Rate limited: {e}")
+
+    # Programmatically wait for the exact time needed
+    print(f"Waiting {e.retry_after} seconds...")
+    time.sleep(e.retry_after)
+
+    # Retry the request
+    issue = m.issue(31660)
+```
+
 ## Documentation
 
 [Read the project documentation](https://mokkari.readthedocs.io/en/stable/?badge=latest)

--- a/mokkari/exceptions.py
+++ b/mokkari/exceptions.py
@@ -31,6 +31,10 @@ class RateLimitError(Exception):
     The rate limiting is enforced locally before making API requests, preventing
     unnecessary HTTP calls that would fail on the server side.
 
+    Attributes:
+        retry_after: Number of seconds to wait before the next request can be made.
+                     This allows applications to implement programmatic retry logic.
+
     Note:
         Applications should catch this exception and implement appropriate retry
         logic or inform users about the rate limit. See the Session class
@@ -48,11 +52,23 @@ class RateLimitError(Exception):
         ...     # "Rate limit exceeded: You have reached the 30 requests per minute limit.
         ...     #  Please wait 1 minute, 30 seconds before making another request."
         ...     print(f"Rate limited: {e}")
+        ...     # Access the numeric delay value for programmatic retry
+        ...     time.sleep(e.retry_after)
     """
 
-    def __init__(self: RateLimitError, *args, **kwargs: dict[str, any]) -> None:
-        """Initialize a RateLimitError."""
-        Exception.__init__(self, *args, **kwargs)
+    def __init__(
+        self: RateLimitError,
+        message: str,
+        retry_after: float = 0,
+    ) -> None:
+        """Initialize a RateLimitError.
+
+        Args:
+            message: The error message describing the rate limit condition.
+            retry_after: Number of seconds to wait before the next request (default: 0).
+        """
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 class AuthenticationError(Exception):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1362,6 +1362,9 @@ def test_rate_limit_minute_exceeded(session: Session) -> None:
         assert "Please wait" in error_msg
         assert "1 minute" in error_msg
 
+        # Verify retry_after attribute is set correctly (60000 ms = 60 seconds)
+        assert excinfo.value.retry_after == 60.0
+
 
 def test_rate_limit_day_exceeded(session: Session) -> None:
     """Test that daily rate limit raises RateLimitError with correct message."""
@@ -1382,6 +1385,9 @@ def test_rate_limit_day_exceeded(session: Session) -> None:
         assert "10,000 requests per day" in error_msg
         assert "Please wait" in error_msg
         assert "24 hours" in error_msg
+
+        # Verify retry_after attribute is set correctly (86400000 ms = 86400 seconds)
+        assert excinfo.value.retry_after == 86400.0
 
 
 def test_rate_limit_blocks_request(session: Session, monkeypatch) -> None:


### PR DESCRIPTION
This PR adds retry_after attribute to RateLimitError for programmatic retry handling

Previously, RateLimitError only included a human-readable time string in the
error message (e.g., "Please wait 1 minute, 30 seconds"). Applications that
wanted to implement automatic retry logic had no way to access the numeric
delay value programmatically.

Changes:
- Add retry_after attribute to RateLimitError storing delay in seconds
- Update RateLimitError.__init__() to accept message and retry_after parameters
- Pass delay values when raising RateLimitError in session.py:
  * Local rate limiting (minute/day limits)
  * HTTP 429 responses (Retry-After header)
- Update tests to verify retry_after attribute is set correctly
- Add Rate Limiting section to README with usage examples
- Enhance RateLimitError docstring with attribute documentation

This allows applications to implement robust retry logic:
```python
try:
    issue = m.issue(1)
except RateLimitError as e:
    time.sleep(e.retry_after)  # Wait exact time needed
    issue = m.issue(1)  # Retry
```