### PR TITLE
Fix ReadingListRead schema to handle empty attribution_url

### DIFF
--- a/mokkari/schemas/reading_list.py
+++ b/mokkari/schemas/reading_list.py
@@ -170,3 +170,21 @@ class ReadingListRead(BaseModel):
     items_url: str
     resource_url: str
     modified: datetime
+
+    @field_validator("attribution_url", mode="before")
+    @classmethod
+    def convert_empty_string_to_none(_cls, v: str | None) -> str | None:  # noqa: N804
+        """Convert empty strings to None for attribution_url.
+
+        The API may return an empty string when there is no attribution URL,
+        but we want to store this as None internally.
+
+        Args:
+            v: The value to validate
+
+        Returns:
+            None if the value is an empty string, otherwise the original value
+        """
+        if v == "":
+            return None
+        return v

--- a/tests/test_reading_list_schemas.py
+++ b/tests/test_reading_list_schemas.py
@@ -367,6 +367,30 @@ def test_reading_list_no_average_rating(user_data):
     assert reading_list.average_rating is None
 
 
+def test_reading_list_read_empty_attribution_url(user_data):
+    """Test that empty string attribution_url is converted to None.
+
+    This handles the case where the API returns an empty string instead of null
+    for the attribution_url field.
+    """
+    data = {
+        "id": 197,
+        "user": user_data,
+        "name": "Test Reading List",
+        "slug": "test-reading-list",
+        "attribution_source": "CBRO",
+        "attribution_url": "",
+        "average_rating": 0.0,
+        "rating_count": 0,
+        "items_url": "https://api.example.com/reading_list/197/items/",
+        "resource_url": "https://api.example.com/reading_list/197/",
+        "modified": "2025-12-30T12:00:00Z",
+    }
+    reading_list = ReadingListRead(**data)
+    assert reading_list.id == 197
+    assert reading_list.attribution_url is None
+
+
 # Edge cases and integration tests
 def test_private_reading_list(user_data):
     """Test creating a private reading list."""


### PR DESCRIPTION
Add field validator to convert empty string attribution_url values to None, as the API may return empty strings instead of null for this optional field.