### PR TITLE
Add if_modified_since parameter to detail endpoint methods

### DIFF
--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -444,6 +444,8 @@ class Session:
             url = self.api_url.format("/".join(str(e) for e in [resource_name, _id]))
             if if_modified_since.tzinfo is None:
                 if_modified_since = if_modified_since.replace(tzinfo=timezone.utc)
+            else:
+                if_modified_since = if_modified_since.astimezone(timezone.utc)
             header_value = format_http_datetime(if_modified_since, usegmt=True)
             data = self._fetch_detail(url, header_value)
             if data is None:


### PR DESCRIPTION
This PR adds `if_modified_since` parameter to detail endpoint methods.

Add optional if_modified_since (datetime) parameter to all 11 detail methods: arc, character, creator, imprint, issue, publisher, series, team, universe, reading_list, and collection. When provided, the request includes an If-Modified-Since header (formatted as RFC 7231) and returns None on 304 Not Modified. Without it, the existing cache flow is unchanged. Naive datetimes are treated as UTC.