### PR TITLE
Add support for non-USD currency prices (GBP)

### DIFF
--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -13,6 +13,7 @@ This module provides the following classes:
 - Issue
 - IssuePost
 - IssuePostResponse
+- PricePost
 """
 
 __all__ = [
@@ -26,11 +27,12 @@ __all__ = [
     "IssuePost",
     "IssuePostResponse",
     "IssueSeries",
+    "PricePost",
 ]
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, HttpUrl, StringConstraints
 
@@ -53,6 +55,18 @@ class Credit(BaseModel):
     id: int
     creator: str
     role: list[GenericItem] = []
+
+
+class PricePost(BaseModel):
+    """Price object for non-USD currencies.
+
+    Attributes:
+        amount (Decimal): The price amount.
+        currency (str): The currency code (USD or GBP).
+    """
+
+    amount: Decimal
+    currency: Literal["USD", "GBP"]
 
 
 class CreditPost(BaseModel):
@@ -225,7 +239,8 @@ class IssuePost(BaseModel):
         cover_date (date, optional): The cover date of the issue.
         store_date (date, optional): The store date of the issue.
         foc_date (date, optional): The final order cutoff date of the issue.
-        price (Decimal, optional): The price of the issue.
+        price (Decimal | PricePost, optional): The price of the issue. Pass a plain Decimal for
+            USD or a PricePost object for non-USD currencies (e.g. GBP).
         rating (int, optional): The ID of the rating of the issue.
         sku (str, optional): The SKU of the issue.
         isbn (str, optional): The ISBN of the issue.
@@ -250,7 +265,7 @@ class IssuePost(BaseModel):
     cover_date: date | None = None
     store_date: date | None = None
     foc_date: date | None = None
-    price: Decimal | None = None
+    price: Decimal | PricePost | None = None
     rating: int | None = None
     sku: Annotated[str, StringConstraints(max_length=12)] | None = None
     isbn: Annotated[str, StringConstraints(max_length=13)] | None = None

--- a/tests/test_issue_schemas.py
+++ b/tests/test_issue_schemas.py
@@ -17,6 +17,7 @@ from mokkari.schemas.issue import (
     IssuePost,
     IssuePostResponse,
     IssueSeries,
+    PricePost,
 )
 
 
@@ -558,10 +559,10 @@ def test_issue_post_response_validation_missing_required():
 # Edge cases and integration tests
 def test_decimal_price_precision():
     """Test that price field handles decimal precision correctly."""
-    issue_post = IssuePost(price="3.99")
+    issue_post = IssuePost(price=Decimal("3.99"))
     assert issue_post.price == Decimal("3.99")
 
-    issue_post = IssuePost(price="10.999")
+    issue_post = IssuePost(price=Decimal("10.999"))
     assert issue_post.price == Decimal("10.999")
 
 
@@ -635,6 +636,66 @@ def test_list_field_types():
     issue = Issue(**data)
     assert len(issue.story_titles) == 3
     assert all(isinstance(title, str) for title in issue.story_titles)
+
+
+# PricePost model tests
+def test_price_post_creation_usd():
+    """Test creating a PricePost with USD currency."""
+    price = PricePost(amount=Decimal("3.99"), currency="USD")
+    assert price.amount == Decimal("3.99")
+    assert price.currency == "USD"
+
+
+def test_price_post_creation_gbp():
+    """Test creating a PricePost with GBP currency."""
+    price = PricePost(amount=Decimal("3.99"), currency="GBP")
+    assert price.amount == Decimal("3.99")
+    assert price.currency == "GBP"
+
+
+def test_price_post_invalid_currency():
+    """Test that PricePost rejects unsupported currency codes."""
+    with pytest.raises(ValidationError):
+        PricePost(amount=Decimal("3.99"), currency="EUR")
+
+
+def test_price_post_missing_fields():
+    """Test PricePost validation with missing required fields."""
+    with pytest.raises(ValidationError):
+        PricePost(amount=Decimal("3.99"))  # Missing currency
+
+    with pytest.raises(ValidationError):
+        PricePost(currency="GBP")  # Missing amount
+
+
+def test_issue_post_price_accepts_decimal():
+    """Test that IssuePost still accepts a plain Decimal for USD prices."""
+    issue_post = IssuePost(price=Decimal("4.99"))
+    assert issue_post.price == Decimal("4.99")
+
+
+def test_issue_post_price_accepts_price_post_gbp():
+    """Test that IssuePost accepts a PricePost object for GBP prices."""
+    price = PricePost(amount=Decimal("3.99"), currency="GBP")
+    issue_post = IssuePost(price=price)
+    assert isinstance(issue_post.price, PricePost)
+    assert issue_post.price.amount == Decimal("3.99")
+    assert issue_post.price.currency == "GBP"
+
+
+def test_issue_post_price_accepts_price_post_usd():
+    """Test that IssuePost accepts a PricePost object for USD prices."""
+    price = PricePost(amount=Decimal("5.99"), currency="USD")
+    issue_post = IssuePost(price=price)
+    assert isinstance(issue_post.price, PricePost)
+    assert issue_post.price.amount == Decimal("5.99")
+    assert issue_post.price.currency == "USD"
+
+
+def test_issue_post_price_accepts_none():
+    """Test that IssuePost still accepts None for price."""
+    issue_post = IssuePost(price=None)
+    assert issue_post.price is None
 
 
 def test_optional_nested_objects():


### PR DESCRIPTION
## Summary

- Adds `PricePost` model with `amount` (Decimal) and `currency` (USD or GBP) fields to represent non-USD prices in write operations
- Updates `IssuePost.price` to accept either a plain `Decimal` (defaults to USD) or a `PricePost` object, matching the updated Metron API spec
- Adds schema tests covering `PricePost` validation and the updated `IssuePost.price` union type
