### PR TITLE
Add missing fields to MissingSeries schema

### DIFF
--- a/mokkari/schemas/collection.py
+++ b/mokkari/schemas/collection.py
@@ -42,6 +42,7 @@ from enum import Enum
 from pydantic import Field
 
 from mokkari.schemas import BaseModel
+from mokkari.schemas.generic import GenericItem
 from mokkari.schemas.issue import BasicSeries
 from mokkari.schemas.user import User
 
@@ -297,6 +298,12 @@ class MissingSeries(BaseModel):
         sort_name (str): The sort name of the series.
         year_began (int): The year the series began.
         year_end (int, optional): The year the series ended.
+        publisher (GenericItem): The publisher of the series.
+        series_type (GenericItem): The type of the series.
+        total_issues (int): Total number of issues in the series.
+        owned_issues (int): Number of issues owned in the collection.
+        missing_count (int): Number of issues missing from the collection.
+        completion_percentage (float): Percentage of the series that is owned.
     """
 
     id: int
@@ -304,6 +311,12 @@ class MissingSeries(BaseModel):
     sort_name: str
     year_began: int
     year_end: int | None = None
+    publisher: GenericItem
+    series_type: GenericItem
+    total_issues: int
+    owned_issues: int
+    missing_count: int
+    completion_percentage: float
 
 
 class CollectionFormatStat(BaseModel):

--- a/tests/test_collection_schemas.py
+++ b/tests/test_collection_schemas.py
@@ -113,7 +113,7 @@ def test_user_valid_data(user_data):
 def test_user_missing_required_field():
     """Test User model with missing required field."""
     with pytest.raises(ValidationError):
-        User(id=1)
+        User(id=1)  # type: ignore
 
 
 # BookFormat enum tests
@@ -238,6 +238,7 @@ def test_collection_read_valid_data(collection_read_data):
     assert collection.storage_location == "Box 1"
     assert collection.notes == "First appearance"
     assert collection.is_read is True
+    assert collection.date_read is not None
     assert collection.date_read.year == 2024
     assert collection.date_read.month == 1
     assert collection.date_read.day == 20
@@ -293,12 +294,24 @@ def test_missing_series_valid_data():
         "sort_name": "Batman",
         "year_began": 1940,
         "year_end": 2011,
+        "publisher": {"id": 1, "name": "DC Comics"},
+        "series_type": {"id": 1, "name": "Ongoing Series"},
+        "total_issues": 713,
+        "owned_issues": 500,
+        "missing_count": 213,
+        "completion_percentage": 70.12,
     }
     series = MissingSeries(**data)
     assert series.id == 1
     assert series.name == "Batman"
     assert series.year_began == 1940
     assert series.year_end == 2011
+    assert series.publisher.name == "DC Comics"
+    assert series.series_type.name == "Ongoing Series"
+    assert series.total_issues == 713
+    assert series.owned_issues == 500
+    assert series.missing_count == 213
+    assert series.completion_percentage == 70.12
 
 
 def test_missing_series_no_end_year():
@@ -308,6 +321,12 @@ def test_missing_series_no_end_year():
         "name": "Batman",
         "sort_name": "Batman",
         "year_began": 2011,
+        "publisher": {"id": 1, "name": "DC Comics"},
+        "series_type": {"id": 1, "name": "Ongoing Series"},
+        "total_issues": 100,
+        "owned_issues": 50,
+        "missing_count": 50,
+        "completion_percentage": 50.0,
     }
     series = MissingSeries(**data)
     assert series.year_end is None
@@ -369,6 +388,7 @@ def test_scrobble_request_valid_data():
     }
     scrobble = ScrobbleRequest(**data)
     assert scrobble.issue_id == 1
+    assert scrobble.date_read is not None
     assert scrobble.date_read.year == 2024
     assert scrobble.date_read.month == 1
     assert scrobble.date_read.day == 20
@@ -414,7 +434,7 @@ def test_scrobble_request_invalid_rating_too_high():
 def test_scrobble_request_missing_required_field():
     """Test ScrobbleRequest with missing required field."""
     with pytest.raises(ValidationError):
-        ScrobbleRequest()
+        ScrobbleRequest()  # type: ignore
 
 
 # ScrobbleResponse tests
@@ -433,6 +453,7 @@ def test_scrobble_response_valid_data(collection_issue_data):
     assert response.id == 1
     assert response.issue.id == 1
     assert response.is_read is True
+    assert response.date_read is not None
     assert response.date_read.year == 2024
     assert response.date_read.month == 1
     assert response.date_read.day == 20

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,6 +6,7 @@ This module contains tests for Session objects.
 import datetime
 import json
 from decimal import Decimal
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1423,7 +1424,7 @@ def test_collection(session: Session) -> None:
                 storage_location="Box 1",
                 notes="First appearance",
                 is_read=True,
-                date_read=datetime.date(2023, 1, 20),
+                date_read=datetime.datetime(2023, 1, 20, tzinfo=datetime.timezone.utc),
                 rating=5,
                 resource_url="https://api.example.com/collection/1/",
                 created_on=datetime.datetime.now(),
@@ -1611,12 +1612,24 @@ def test_collection_missing_series(session: Session) -> None:
                 "sort_name": "Batman",
                 "year_began": 1940,
                 "year_end": 2011,
+                "publisher": {"id": 1, "name": "DC Comics"},
+                "series_type": {"id": 1, "name": "Ongoing Series"},
+                "total_issues": 713,
+                "owned_issues": 500,
+                "missing_count": 213,
+                "completion_percentage": 70.12,
             },
             {
                 "id": 2,
                 "name": "Superman",
                 "sort_name": "Superman",
                 "year_began": 1938,
+                "publisher": {"id": 1, "name": "DC Comics"},
+                "series_type": {"id": 1, "name": "Ongoing Series"},
+                "total_issues": 500,
+                "owned_issues": 200,
+                "missing_count": 300,
+                "completion_percentage": 40.0,
             },
         ],
         "next": None,
@@ -1632,12 +1645,24 @@ def test_collection_missing_series(session: Session) -> None:
                     sort_name="Batman",
                     year_began=1940,
                     year_end=2011,
+                    publisher=GenericItem(id=1, name="DC Comics"),
+                    series_type=GenericItem(id=1, name="Ongoing Series"),
+                    total_issues=713,
+                    owned_issues=500,
+                    missing_count=213,
+                    completion_percentage=70.12,
                 ),
                 MissingSeries(
                     id=2,
                     name="Superman",
                     sort_name="Superman",
                     year_began=1938,
+                    publisher=GenericItem(id=1, name="DC Comics"),
+                    series_type=GenericItem(id=1, name="Ongoing Series"),
+                    total_issues=500,
+                    owned_issues=200,
+                    missing_count=300,
+                    completion_percentage=40.0,
                 ),
             ],
         ),
@@ -1750,7 +1775,7 @@ def test_collection_scrobble(session: Session) -> None:
 
 def test_collection_scrobble_minimal(session: Session) -> None:
     # Arrange
-    scrobble_request = ScrobbleRequest(issue_id=1)
+    scrobble_request = ScrobbleRequest(issue_id=1, rating=None)
     resp = {
         "id": 100,
         "issue": {
@@ -2011,7 +2036,7 @@ def test__prepare_request_payload_all_set_fields_are_included(session: Session) 
 
 
 def test__prepare_request_payload_image_model_uses_multipart_and_strips_none(
-    session: Session, tmp_path: object
+    session: Session, tmp_path: Path
 ) -> None:
     """Image-field models must still use multipart form data with None values stripped."""
     img_file = tmp_path / "cover.png"


### PR DESCRIPTION
## Summary

Fixes #138. The `MissingSeries` schema was missing several fields returned by the Metron API. This PR adds the following:

- `publisher` (`GenericItem`) — the publisher of the series
- `series_type` (`GenericItem`) — the type of the series
- `total_issues` (`int`) — total number of issues in the series
- `owned_issues` (`int`) — number of issues owned in the collection
- `missing_count` (`int`) — number of issues missing from the collection
- `completion_percentage` (`float`) — percentage of the series owned

Tests and schema fixtures updated to cover the new fields.
