### PR TITLE
Add wish list API support

### DIFF
--- a/docs/mokkari/schemas/wish_list.md
+++ b/docs/mokkari/schemas/wish_list.md
@@ -1,0 +1,7 @@
+:::mokkari.schemas.wish_list.AcquireWishListItem
+:::mokkari.schemas.wish_list.Currency
+:::mokkari.schemas.wish_list.Priority
+:::mokkari.schemas.wish_list.WishList
+:::mokkari.schemas.wish_list.WishListAddItem
+:::mokkari.schemas.wish_list.WishListItemList
+:::mokkari.schemas.wish_list.WishListItemRead

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Universe: mokkari/schemas/universe.md
       - User: mokkari/schemas/user.md
       - Variant: mokkari/schemas/variant.md
+      - Wish List: mokkari/schemas/wish_list.md
 
 plugins:
   - search

--- a/mokkari/schemas/wish_list.py
+++ b/mokkari/schemas/wish_list.py
@@ -1,0 +1,167 @@
+"""Wish list module.
+
+This module provides the following classes:
+
+- Currency
+- Priority
+- WishList
+- WishListItemList
+- WishListItemRead
+- WishListAddItem
+- AcquireWishListItem
+"""
+
+__all__ = [
+    "AcquireWishListItem",
+    "Currency",
+    "Priority",
+    "WishList",
+    "WishListAddItem",
+    "WishListItemList",
+    "WishListItemRead",
+]
+
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+
+from pydantic import Field
+
+from mokkari.schemas import BaseModel
+from mokkari.schemas.collection import CollectionIssue, Grade
+
+
+class Priority(int, Enum):
+    """Enumeration of wish list item priority levels (1=highest, 5=lowest).
+
+    Values:
+
+        ONE: Priority 1 (highest)
+        TWO: Priority 2
+        THREE: Priority 3 (default)
+        FOUR: Priority 4
+        FIVE: Priority 5 (lowest)
+    """
+
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+
+
+class Currency(str, Enum):
+    """Enumeration of supported currencies.
+
+    Values:
+
+        USD: US Dollar
+        GBP: British Pound Sterling
+    """
+
+    USD = "USD"
+    GBP = "GBP"
+
+
+class WishList(BaseModel):
+    """A data model representing a user's wish list.
+
+    Attributes:
+        id (int): The unique identifier of the wish list.
+        item_count (int): Number of items in the wish list.
+        items_url (str): URL to retrieve the wish list items.
+        modified (datetime): The date and time when the wish list was last modified.
+    """
+
+    id: int
+    item_count: int
+    items_url: str
+    modified: datetime
+
+
+class WishListItemList(BaseModel):
+    """A data model representing a wish list item in list view.
+
+    Attributes:
+        id (int): The unique identifier of the wish list item.
+        issue (CollectionIssue): The issue associated with this wish list item.
+        status (str): The current status of the wish list item.
+        priority (Priority, optional): The priority level for acquiring this item.
+        desired_grade (Grade, optional): The desired CGC grade for the issue.
+        modified (datetime): The date and time when the item was last modified.
+    """
+
+    id: int
+    issue: CollectionIssue
+    status: str
+    priority: Priority | None = None
+    desired_grade: Grade | None = None
+    modified: datetime
+
+
+class WishListItemRead(BaseModel):
+    """A data model representing a wish list item in detailed view.
+
+    Attributes:
+        id (int): The unique identifier of the wish list item.
+        issue (CollectionIssue): The issue associated with this wish list item.
+        status (str): The current status of the wish list item.
+        priority (Priority, optional): The priority level for acquiring this item.
+        desired_grade (Grade, optional): The desired CGC grade for the issue.
+        max_price (Decimal, optional): The maximum price willing to pay.
+        max_price_currency (str, optional): Currency code for max_price (e.g. "USD", "GBP").
+        notes (str): Additional notes about this wish list item.
+        added_on (datetime): The date and time when the item was added to the wish list.
+        modified (datetime): The date and time when the item was last modified.
+    """
+
+    id: int
+    issue: CollectionIssue
+    status: str
+    priority: Priority | None = None
+    desired_grade: Grade | None = None
+    max_price: Decimal | None = None
+    max_price_currency: str | None = None
+    notes: str = ""
+    added_on: datetime
+    modified: datetime
+
+
+class WishListAddItem(BaseModel):
+    """A data model representing a request to add an issue to the wish list.
+
+    Attributes:
+        issue_id (int): The unique identifier of the issue to add.
+        priority (int): Priority level 1-5 (default 3).
+        desired_grade (Decimal, optional): The desired CGC grade for the issue.
+        max_price (Decimal, optional): The maximum price willing to pay.
+        max_price_currency (str): Currency for max_price (default "USD").
+        notes (str): Additional notes about this wish list item.
+    """
+
+    issue_id: int
+    priority: int = Field(default=3, ge=1, le=5)
+    desired_grade: Decimal | None = None
+    max_price: Decimal | None = None
+    max_price_currency: str = "USD"
+    notes: str = ""
+
+
+class AcquireWishListItem(BaseModel):
+    """A data model representing a request to mark a wish list item as acquired.
+
+    This creates a new collection item from the wish list item.
+
+    Attributes:
+        purchase_date (date, optional): The date the issue was purchased.
+        purchase_price (Decimal, optional): The price paid for the issue.
+        purchase_price_currency (str): Currency for purchase_price (default "USD").
+        purchase_store (str): The store or vendor where the issue was purchased.
+        notes (str): Additional notes about the purchase.
+    """
+
+    purchase_date: date | None = None
+    purchase_price: Decimal | None = None
+    purchase_price_currency: str = "USD"
+    purchase_store: str = ""
+    notes: str = ""

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -54,6 +54,13 @@ from mokkari.schemas.series import BaseSeries, Series, SeriesPost, SeriesPostRes
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
 from mokkari.schemas.universe import Universe, UniversePost, UniversePostResponse
 from mokkari.schemas.variant import VariantPost, VariantPostResponse
+from mokkari.schemas.wish_list import (
+    AcquireWishListItem,
+    WishList,
+    WishListAddItem,
+    WishListItemList,
+    WishListItemRead,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -102,6 +109,7 @@ class ResourceEndpoint:
     SERIES: Final[str] = "series"
     TEAM: Final[str] = "team"
     UNIVERSE: Final[str] = "universe"
+    WISH_LIST: Final[str] = "wish_list"
 
 
 def format_time(seconds: str | float) -> str:
@@ -420,6 +428,34 @@ class Session:
             return adapter.validate_python(resp["results"])
         except ValidationError as error:
             raise exceptions.ApiError(error) from error
+
+    def _send_void(self, method: str, endpoint: list[str | int], data: Any = None) -> None:
+        """Send a request that returns no response body (204 No Content or 200 with no body).
+
+        Args:
+            method: HTTP method to use ("POST" or "DELETE").
+            endpoint: List of path segments to build the API endpoint URL.
+            data: Optional data to send in the request body.
+
+        Raises:
+            ApiError: If the request fails.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+        """
+        url = self.api_url.format("/".join(str(e) for e in endpoint))
+        self._check_rate_limit()
+        header, files, data_dict = self._prepare_request_payload(data)
+        response = self._execute_http_request(method, url, {}, header, data_dict, files)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if err.response.status_code == requests.codes.too_many:
+                retry_after = float(response.headers.get("Retry-After", 0))
+                msg = (
+                    f"Metron API Rate Limit exceeded, need to wait for {format_time(retry_after)}."
+                )
+                raise exceptions.RateLimitError(msg, retry_after=retry_after) from err
+            msg = f"HTTP error: {err!r} | Response body: {response.text}"
+            raise exceptions.ApiError(msg) from err
 
     def _handle_write_request(
         self, method: str, endpoint: list[str | int], data: Any, response_class: type
@@ -1523,6 +1559,137 @@ class Session:
         return self._handle_write_request(
             "POST", [ResourceEndpoint.COLLECTION, "scrobble"], data, ScrobbleResponse
         )
+
+    # Wish list methods
+    def wish_list(self, _id: int) -> WishList:
+        """Retrieve a wish list by ID.
+
+        Note: This endpoint requires authentication. Users can only access their own wish lists.
+
+        Args:
+            _id: The unique identifier for the wish list.
+
+        Returns:
+            A WishList object.
+
+        Raises:
+            ApiError: If the wish list is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> wl = session.wish_list(1)
+            >>> print(f"Items: {wl.item_count}")
+        """
+        return self._get_resource(ResourceEndpoint.WISH_LIST, _id, WishList)
+
+    def wish_lists_list(self, params: dict[str, str | int] | None = None) -> list[WishList]:
+        """Retrieve a list of wish lists for the authenticated user.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            params: Optional dictionary of query parameters for filtering results.
+
+        Returns:
+            list[WishList]: A list of WishList objects.
+
+        Raises:
+            ApiError: If there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> lists = session.wish_lists_list()
+        """
+        return self._list_resources(ResourceEndpoint.WISH_LIST, params, WishList)
+
+    def wish_list_items(self, params: dict[str, str | int] | None = None) -> list[WishListItemList]:
+        """Retrieve wish list items for the authenticated user.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            params: Optional dictionary of query parameters for filtering results.
+
+        Returns:
+            list[WishListItemList]: A list of WishListItemList objects.
+
+        Raises:
+            ApiError: If there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> items = session.wish_list_items()
+            >>> for item in items:
+            ...     print(f"{item.issue.series.name} #{item.issue.number} - {item.status}")
+        """
+        resp = self._get_results([ResourceEndpoint.WISH_LIST, "items"], params)
+        return self._validate_list_response(resp, WishListItemList)
+
+    def wish_list_add_item(self, data: WishListAddItem) -> WishListItemRead:
+        """Add an issue to the authenticated user's wish list.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            data: WishListAddItem object containing the issue_id and optional fields.
+
+        Returns:
+            WishListItemRead: The newly created wish list item.
+
+        Raises:
+            ApiError: If the issue is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> from mokkari.schemas.wish_list import WishListAddItem
+            >>> item = session.wish_list_add_item(WishListAddItem(issue_id=1, priority=2))
+            >>> print(f"Added: {item.issue.series.name} #{item.issue.number}")
+        """
+        return self._handle_write_request(
+            "POST", [ResourceEndpoint.WISH_LIST, "items", "add"], data, WishListItemRead
+        )
+
+    def wish_list_acquire_item(self, item_pk: int, data: AcquireWishListItem) -> None:
+        """Mark a wish list item as acquired and create a collection item.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            item_pk: The unique identifier of the wish list item to acquire.
+            data: AcquireWishListItem object with optional purchase details.
+
+        Raises:
+            ApiError: If the item is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> from mokkari.schemas.wish_list import AcquireWishListItem
+            >>> session.wish_list_acquire_item(1, AcquireWishListItem(purchase_price="9.99"))
+        """
+        self._send_void("POST", [ResourceEndpoint.WISH_LIST, "items", item_pk, "acquire"], data)
+
+    def wish_list_remove_item(self, item_pk: int) -> None:
+        """Remove an item from the authenticated user's wish list.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            item_pk: The unique identifier of the wish list item to remove.
+
+        Raises:
+            ApiError: If the item is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> session.wish_list_remove_item(1)
+        """
+        self._send_void("DELETE", [ResourceEndpoint.WISH_LIST, "items", item_pk, "remove"])
 
     def _get_results(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -56,6 +56,14 @@ from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
 from mokkari.schemas.universe import Universe, UniversePost, UniversePostResponse
 from mokkari.schemas.user import User
 from mokkari.schemas.variant import VariantPost, VariantPostResponse
+from mokkari.schemas.wish_list import (
+    AcquireWishListItem,
+    Priority,
+    WishList,
+    WishListAddItem,
+    WishListItemList,
+    WishListItemRead,
+)
 from mokkari.session import Session
 
 
@@ -2444,3 +2452,194 @@ def test_default_bucket_shared_across_sessions() -> None:
         assert s1._bucket is s2._bucket
     finally:
         session_module._default_bucket_instance = original
+
+
+def test_wish_list(session: Session) -> None:
+    # Arrange
+    resp = {
+        "id": 1,
+        "item_count": 5,
+        "items_url": "https://metron.cloud/api/wish_list/1/items/",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    with (
+        patch.object(session, "_get", return_value=resp),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=WishList(
+                id=1,
+                item_count=5,
+                items_url="https://metron.cloud/api/wish_list/1/items/",
+                modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            ),
+        ),
+    ):
+        # Act
+        result = session.wish_list(1)
+        # Assert
+        assert isinstance(result, WishList)
+        assert result.id == 1
+        assert result.item_count == 5
+
+
+def test_wish_lists_list(session: Session) -> None:
+    # Arrange
+    resp = {
+        "results": [
+            {
+                "id": 1,
+                "item_count": 5,
+                "items_url": "https://metron.cloud/api/wish_list/1/items/",
+                "modified": "2024-01-01T12:00:00Z",
+            }
+        ],
+        "next": None,
+    }
+    with (
+        patch.object(session, "_get_results", return_value=resp),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=[
+                WishList(
+                    id=1,
+                    item_count=5,
+                    items_url="https://metron.cloud/api/wish_list/1/items/",
+                    modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                )
+            ],
+        ),
+    ):
+        # Act
+        result = session.wish_lists_list()
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].id == 1
+        assert result[0].item_count == 5
+
+
+def test_wish_list_items(session: Session) -> None:
+    # Arrange
+    resp = {
+        "results": [
+            {
+                "id": 10,
+                "issue": {
+                    "id": 1,
+                    "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                    "number": "1",
+                    "cover_date": "2024-01-01",
+                    "modified": "2024-01-01T12:00:00Z",
+                },
+                "status": "Wanted",
+                "priority": 3,
+                "modified": "2024-01-01T12:00:00Z",
+            }
+        ],
+        "next": None,
+    }
+    with (
+        patch.object(session, "_get_results", return_value=resp),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=[
+                WishListItemList(
+                    id=10,
+                    issue=CollectionIssue(
+                        id=1,
+                        series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                        number="1",
+                        cover_date=datetime.date(2024, 1, 1),
+                        modified=datetime.datetime(
+                            2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                    ),
+                    status="Wanted",
+                    priority=Priority.THREE,
+                    modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                )
+            ],
+        ),
+    ):
+        # Act
+        result = session.wish_list_items()
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].id == 10
+        assert result[0].status == "Wanted"
+
+
+def test_wish_list_add_item(session: Session) -> None:
+    # Arrange
+    add_request = WishListAddItem(issue_id=1, priority=2, notes="High priority")
+    resp = {
+        "id": 10,
+        "issue": {
+            "id": 1,
+            "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+            "number": "1",
+            "cover_date": "2024-01-01",
+            "modified": "2024-01-01T12:00:00Z",
+        },
+        "status": "Wanted",
+        "priority": 2,
+        "max_price_currency": None,
+        "notes": "High priority",
+        "added_on": "2024-01-01T10:00:00Z",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    with (
+        patch.object(session, "_send", return_value=resp),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=WishListItemRead(
+                id=10,
+                issue=CollectionIssue(
+                    id=1,
+                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    number="1",
+                    cover_date=datetime.date(2024, 1, 1),
+                    modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                ),
+                status="Wanted",
+                priority=Priority.TWO,
+                max_price_currency=None,
+                notes="High priority",
+                added_on=datetime.datetime(2024, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+                modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            ),
+        ),
+    ):
+        # Act
+        result = session.wish_list_add_item(add_request)
+        # Assert
+        assert isinstance(result, WishListItemRead)
+        assert result.id == 10
+        assert result.status == "Wanted"
+        assert result.notes == "High priority"
+
+
+def test_wish_list_acquire_item(session: Session) -> None:
+    # Arrange
+    acquire_request = AcquireWishListItem(
+        purchase_price=Decimal("9.99"), purchase_store="Local Comic Shop"
+    )
+    with patch.object(session, "_send_void") as mock_send_void:
+        # Act
+        result = session.wish_list_acquire_item(10, acquire_request)
+        # Assert
+        assert result is None
+        mock_send_void.assert_called_once_with(
+            "POST", ["wish_list", "items", 10, "acquire"], acquire_request
+        )
+
+
+def test_wish_list_remove_item(session: Session) -> None:
+    # Arrange
+    with patch.object(session, "_send_void") as mock_send_void:
+        # Act
+        result = session.wish_list_remove_item(10)
+        # Assert
+        assert result is None
+        mock_send_void.assert_called_once_with("DELETE", ["wish_list", "items", 10, "remove"])

--- a/tests/test_wish_list_schemas.py
+++ b/tests/test_wish_list_schemas.py
@@ -1,0 +1,242 @@
+"""Tests for the wish_list module."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from mokkari.schemas.wish_list import (
+    AcquireWishListItem,
+    Currency,
+    Priority,
+    WishList,
+    WishListAddItem,
+    WishListItemList,
+    WishListItemRead,
+)
+
+
+@pytest.fixture
+def basic_series_data():
+    """Sample basic series data."""
+    return {"name": "Batman", "volume": 1, "year_began": 1940}
+
+
+@pytest.fixture
+def collection_issue_data(basic_series_data):
+    """Sample collection issue data."""
+    return {
+        "id": 1,
+        "series": basic_series_data,
+        "number": "1",
+        "cover_date": "2024-01-01",
+        "store_date": "2023-12-15",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+
+
+# Priority enum tests
+def test_priority_enum_values():
+    """Test Priority enum values."""
+    assert Priority.ONE.value == 1
+    assert Priority.TWO.value == 2
+    assert Priority.THREE.value == 3
+    assert Priority.FOUR.value == 4
+    assert Priority.FIVE.value == 5
+
+
+# Currency enum tests
+def test_currency_enum_values():
+    """Test Currency enum values."""
+    assert Currency.USD.value == "USD"
+    assert Currency.GBP.value == "GBP"
+
+
+# WishList tests
+def test_wish_list_valid_data():
+    """Test WishList model with valid data."""
+    data = {
+        "id": 1,
+        "item_count": 5,
+        "items_url": "https://metron.cloud/api/wish_list/1/items/",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    wl = WishList(**data)
+    assert wl.id == 1
+    assert wl.item_count == 5
+    assert wl.items_url == "https://metron.cloud/api/wish_list/1/items/"
+    assert wl.modified.year == 2024
+
+
+def test_wish_list_missing_required_field():
+    """Test WishList model with missing required field."""
+    with pytest.raises(ValidationError):
+        WishList(id=1, item_count=5, modified="2024-01-01T12:00:00Z")  # type: ignore
+
+
+# WishListItemList tests
+def test_wish_list_item_list_valid_data(collection_issue_data):
+    """Test WishListItemList model with valid data."""
+    data = {
+        "id": 10,
+        "issue": collection_issue_data,
+        "status": "Wanted",
+        "priority": 3,
+        "desired_grade": 9.8,
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    item = WishListItemList(**data)
+    assert item.id == 10
+    assert item.issue.number == "1"
+    assert item.status == "Wanted"
+    assert item.priority == Priority.THREE
+    assert item.desired_grade == 9.8
+    assert item.modified.year == 2024
+
+
+def test_wish_list_item_list_optional_fields(collection_issue_data):
+    """Test WishListItemList with optional fields omitted."""
+    data = {
+        "id": 10,
+        "issue": collection_issue_data,
+        "status": "Wanted",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    item = WishListItemList(**data)
+    assert item.priority is None
+    assert item.desired_grade is None
+
+
+def test_wish_list_item_list_missing_required_field(collection_issue_data):
+    """Test WishListItemList with missing required field."""
+    with pytest.raises(ValidationError):
+        WishListItemList(id=10, issue=collection_issue_data)  # type: ignore
+
+
+# WishListItemRead tests
+def test_wish_list_item_read_valid_data(collection_issue_data):
+    """Test WishListItemRead model with valid data."""
+    data = {
+        "id": 10,
+        "issue": collection_issue_data,
+        "status": "Wanted",
+        "priority": 2,
+        "desired_grade": 9.4,
+        "max_price": "25.00",
+        "max_price_currency": "USD",
+        "notes": "Looking for high grade copy",
+        "added_on": "2024-01-01T10:00:00Z",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    item = WishListItemRead(**data)
+    assert item.id == 10
+    assert item.issue.series.name == "Batman"
+    assert item.status == "Wanted"
+    assert item.priority == Priority.TWO
+    assert item.desired_grade == 9.4
+    assert item.max_price == Decimal("25.00")
+    assert item.max_price_currency == "USD"
+    assert item.notes == "Looking for high grade copy"
+    assert item.added_on.year == 2024
+    assert item.modified.year == 2024
+
+
+def test_wish_list_item_read_optional_fields(collection_issue_data):
+    """Test WishListItemRead with optional fields omitted."""
+    data = {
+        "id": 10,
+        "issue": collection_issue_data,
+        "status": "Wanted",
+        "added_on": "2024-01-01T10:00:00Z",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    item = WishListItemRead(**data)
+    assert item.priority is None
+    assert item.desired_grade is None
+    assert item.max_price is None
+    assert item.max_price_currency is None
+    assert item.notes == ""
+
+
+# WishListAddItem tests
+def test_wish_list_add_item_valid_data():
+    """Test WishListAddItem model with valid data."""
+    data = {
+        "issue_id": 42,
+        "priority": 1,
+        "desired_grade": "9.8",
+        "max_price": "50.00",
+        "max_price_currency": "GBP",
+        "notes": "Must have",
+    }
+    item = WishListAddItem(**data)
+    assert item.issue_id == 42
+    assert item.priority == 1
+    assert item.desired_grade == Decimal("9.8")
+    assert item.max_price == Decimal("50.00")
+    assert item.max_price_currency == "GBP"
+    assert item.notes == "Must have"
+
+
+def test_wish_list_add_item_defaults():
+    """Test WishListAddItem default values."""
+    item = WishListAddItem(issue_id=1)
+    assert item.priority == 3
+    assert item.desired_grade is None
+    assert item.max_price is None
+    assert item.max_price_currency == "USD"
+    assert item.notes == ""
+
+
+def test_wish_list_add_item_missing_required_field():
+    """Test WishListAddItem with missing required field."""
+    with pytest.raises(ValidationError):
+        WishListAddItem()  # type: ignore
+
+
+def test_wish_list_add_item_priority_too_low():
+    """Test WishListAddItem with priority below minimum."""
+    with pytest.raises(ValidationError):
+        WishListAddItem(issue_id=1, priority=0)
+
+
+def test_wish_list_add_item_priority_too_high():
+    """Test WishListAddItem with priority above maximum."""
+    with pytest.raises(ValidationError):
+        WishListAddItem(issue_id=1, priority=6)
+
+
+# AcquireWishListItem tests
+def test_acquire_wish_list_item_valid_data():
+    """Test AcquireWishListItem model with valid data."""
+    data = {
+        "purchase_date": "2024-03-15",
+        "purchase_price": "12.99",
+        "purchase_price_currency": "USD",
+        "purchase_store": "Local Comic Shop",
+        "notes": "Good condition",
+    }
+    item = AcquireWishListItem(**data)
+    assert item.purchase_date == date(2024, 3, 15)
+    assert item.purchase_price == Decimal("12.99")
+    assert item.purchase_price_currency == "USD"
+    assert item.purchase_store == "Local Comic Shop"
+    assert item.notes == "Good condition"
+
+
+def test_acquire_wish_list_item_defaults():
+    """Test AcquireWishListItem default values."""
+    item = AcquireWishListItem()
+    assert item.purchase_date is None
+    assert item.purchase_price is None
+    assert item.purchase_price_currency == "USD"
+    assert item.purchase_store == ""
+    assert item.notes == ""
+
+
+def test_acquire_wish_list_item_gbp_currency():
+    """Test AcquireWishListItem with GBP currency."""
+    item = AcquireWishListItem(purchase_price="8.50", purchase_price_currency="GBP")
+    assert item.purchase_price == Decimal("8.50")
+    assert item.purchase_price_currency == "GBP"


### PR DESCRIPTION
## Summary

- Add `mokkari/schemas/wish_list.py` with Pydantic models for `WishList`, `WishListItemList`, `WishListItemRead`, `WishListAddItem`, and
  `AcquireWishListItem` (plus `Priority` and `Currency` enums)
- Add six new `Session` methods: `wish_list()`, `wish_lists_list()`, `wish_list_items()`, `wish_list_add_item()`, `wish_list_acquire_item()`, and `wish_list_remove_item()`
- Add internal `_send_void()` helper for endpoints that return no response body (200 with empty body for acquire, 204 for remove)
- Add unit tests for all new schemas and session methods
