### PR TITLE
Add pull list API support

### DIFF
--- a/docs/mokkari/schemas/pull_list.md
+++ b/docs/mokkari/schemas/pull_list.md
@@ -1,3 +1,5 @@
+:::mokkari.schemas.pull_list.PullListAddSeries
 :::mokkari.schemas.pull_list.PullListIssue
 :::mokkari.schemas.pull_list.PullListRead
 :::mokkari.schemas.pull_list.PullListSeries
+:::mokkari.schemas.pull_list.PullListSeriesDetail

--- a/docs/mokkari/schemas/pull_list.md
+++ b/docs/mokkari/schemas/pull_list.md
@@ -1,0 +1,3 @@
+:::mokkari.schemas.pull_list.PullListIssue
+:::mokkari.schemas.pull_list.PullListRead
+:::mokkari.schemas.pull_list.PullListSeries

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Imprint: mokkari/schemas/imprint.md
       - Issue: mokkari/schemas/issue.md
       - Publisher: mokkari/schemas/publisher.md
+      - Pull List: mokkari/schemas/pull_list.md
       - Reading List: mokkari/schemas/reading_list.md
       - Reprint: mokkari/schemas/reprint.md
       - Series: mokkari/schemas/series.md

--- a/mokkari/schemas/pull_list.py
+++ b/mokkari/schemas/pull_list.py
@@ -1,0 +1,76 @@
+"""Pull list module.
+
+This module provides the following classes:
+
+- PullListRead
+- PullListIssue
+- PullListSeries
+"""
+
+__all__ = [
+    "PullListIssue",
+    "PullListRead",
+    "PullListSeries",
+]
+
+from datetime import date, datetime
+
+from pydantic import HttpUrl
+
+from mokkari.schemas import BaseModel
+from mokkari.schemas.issue import BasicSeries
+from mokkari.schemas.series import BaseSeries
+
+
+class PullListRead(BaseModel):
+    """A data model representing a user's pull list.
+
+    Attributes:
+        id (int): The unique identifier of the pull list.
+        series_count (int): Number of series on the pull list.
+        series_url (str): URL to retrieve the pull list series.
+        modified (datetime): The date and time when the pull list was last modified.
+    """
+
+    id: int
+    series_count: int
+    series_url: str
+    modified: datetime
+
+
+class PullListIssue(BaseModel):
+    """A data model representing an issue on the pull list.
+
+    Attributes:
+        id (int): The unique identifier of the issue.
+        series (BasicSeries): The series associated with the issue.
+        number (str): The issue number.
+        issue (str): The full issue name/display string.
+        cover_date (date): The cover date of the issue.
+        store_date (date, optional): The in-store date of the issue.
+        image (HttpUrl, optional): The cover image URL.
+        modified (datetime): The date and time when the issue was last modified.
+    """
+
+    id: int
+    series: BasicSeries
+    number: str
+    issue: str
+    cover_date: date
+    store_date: date | None = None
+    image: HttpUrl | None = None
+    modified: datetime
+
+
+class PullListSeries(BaseModel):
+    """A data model representing a series on the pull list.
+
+    Attributes:
+        id (int): The unique identifier of the pull list series entry.
+        series (BaseSeries): The series details.
+        added_on (datetime): The date and time when the series was added to the pull list.
+    """
+
+    id: int
+    series: BaseSeries
+    added_on: datetime

--- a/mokkari/schemas/pull_list.py
+++ b/mokkari/schemas/pull_list.py
@@ -2,24 +2,57 @@
 
 This module provides the following classes:
 
-- PullListRead
+- PullListAddSeries
 - PullListIssue
+- PullListRead
 - PullListSeries
+- PullListSeriesDetail
 """
 
 __all__ = [
+    "PullListAddSeries",
     "PullListIssue",
     "PullListRead",
     "PullListSeries",
+    "PullListSeriesDetail",
 ]
 
 from datetime import date, datetime
 
-from pydantic import HttpUrl
+from pydantic import Field, HttpUrl
 
 from mokkari.schemas import BaseModel
 from mokkari.schemas.issue import BasicSeries
-from mokkari.schemas.series import BaseSeries
+
+
+class PullListAddSeries(BaseModel):
+    """A data model representing a request to add a series to the pull list.
+
+    Attributes:
+        series_id (int): The unique identifier of the series to add.
+    """
+
+    series_id: int
+
+
+class PullListSeriesDetail(BaseModel):
+    """A data model representing series details within a pull list entry.
+
+    Attributes:
+        id (int): The unique identifier of the series.
+        name (str): The name of the series.
+        year_began (int): The year the series began.
+        year_end (int, optional): The year the series ended.
+        volume (int): The volume number of the series.
+        modified (datetime): The date and time when the series was last modified.
+    """
+
+    id: int
+    name: str = Field(alias="series")
+    year_began: int
+    year_end: int | None = None
+    volume: int
+    modified: datetime
 
 
 class PullListRead(BaseModel):
@@ -67,10 +100,10 @@ class PullListSeries(BaseModel):
 
     Attributes:
         id (int): The unique identifier of the pull list series entry.
-        series (BaseSeries): The series details.
+        series (PullListSeriesDetail): The series details.
         added_on (datetime): The date and time when the series was added to the pull list.
     """
 
     id: int
-    series: BaseSeries
+    series: PullListSeriesDetail
     added_on: datetime

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -49,6 +49,7 @@ from mokkari.schemas.issue import (
     IssuePostResponse,
 )
 from mokkari.schemas.publisher import Publisher, PublisherPost
+from mokkari.schemas.pull_list import PullListIssue, PullListRead, PullListSeries
 from mokkari.schemas.reading_list import ReadingListItem, ReadingListList, ReadingListRead
 from mokkari.schemas.series import BaseSeries, Series, SeriesPost, SeriesPostResponse
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
@@ -109,6 +110,7 @@ class ResourceEndpoint:
     SERIES: Final[str] = "series"
     TEAM: Final[str] = "team"
     UNIVERSE: Final[str] = "universe"
+    PULL_LIST: Final[str] = "pull_list"
     WISH_LIST: Final[str] = "wish_list"
 
 
@@ -1560,39 +1562,14 @@ class Session:
             "POST", [ResourceEndpoint.COLLECTION, "scrobble"], data, ScrobbleResponse
         )
 
-    # Wish list methods
-    def wish_list(self, _id: int) -> WishList:
-        """Retrieve a wish list by ID.
-
-        Note: This endpoint requires authentication. Users can only access their own wish lists.
-
-        Args:
-            _id: The unique identifier for the wish list.
-
-        Returns:
-            A WishList object.
-
-        Raises:
-            ApiError: If the wish list is not found or if there's an API error.
-            RateLimitError: If the Metron API rate limit has been exceeded.
-
-        Examples:
-            >>> session = Session("username", "password")
-            >>> wl = session.wish_list(1)
-            >>> print(f"Items: {wl.item_count}")
-        """
-        return self._get_resource(ResourceEndpoint.WISH_LIST, _id, WishList)
-
-    def wish_lists_list(self, params: dict[str, str | int] | None = None) -> list[WishList]:
-        """Retrieve a list of wish lists for the authenticated user.
+    # Pull list methods
+    def pull_list(self) -> PullListRead:
+        """Retrieve the authenticated user's pull list.
 
         Note: This endpoint requires authentication.
 
-        Args:
-            params: Optional dictionary of query parameters for filtering results.
-
         Returns:
-            list[WishList]: A list of WishList objects.
+            A PullListRead object.
 
         Raises:
             ApiError: If there's an API error.
@@ -1600,9 +1577,126 @@ class Session:
 
         Examples:
             >>> session = Session("username", "password")
-            >>> lists = session.wish_lists_list()
+            >>> pl = session.pull_list()
+            >>> print(f"Series: {pl.series_count}")
         """
-        return self._list_resources(ResourceEndpoint.WISH_LIST, params, WishList)
+        results = self._list_resources(ResourceEndpoint.PULL_LIST, None, PullListRead)
+        return results[0]
+
+    def pull_list_issues(self, params: dict[str, str | int] | None = None) -> list[PullListIssue]:
+        """Retrieve issues for series on the authenticated user's pull list.
+
+        Optionally filter by store date using store_date_after and store_date_before.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            params: Optional dictionary of query parameters. Supports:
+                - store_date_after: Return issues with a store date on or after this date (YYYY-MM-DD).
+                - store_date_before: Return issues with a store date on or before this date (YYYY-MM-DD).
+
+        Returns:
+            list[PullListIssue]: A list of PullListIssue objects.
+
+        Raises:
+            ApiError: If there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> issues = session.pull_list_issues({"store_date_after": "2024-01-01"})
+            >>> for issue in issues:
+            ...     print(f"{issue.series.name} #{issue.number}")
+        """
+        resp = self._get_results([ResourceEndpoint.PULL_LIST, "issues"], params)
+        return self._validate_list_response(resp, PullListIssue)
+
+    def pull_list_series(self, params: dict[str, str | int] | None = None) -> list[PullListSeries]:
+        """Retrieve the series on the authenticated user's pull list.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            params: Optional dictionary of query parameters for filtering results.
+
+        Returns:
+            list[PullListSeries]: A list of PullListSeries objects.
+
+        Raises:
+            ApiError: If there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> series_list = session.pull_list_series()
+            >>> for entry in series_list:
+            ...     print(entry.series.display_name)
+        """
+        resp = self._get_results([ResourceEndpoint.PULL_LIST, "series"], params)
+        return self._validate_list_response(resp, PullListSeries)
+
+    def pull_list_add_series(self, series_id: int) -> PullListSeries:
+        """Add a series to the authenticated user's pull list.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            series_id: The unique identifier of the series to add.
+
+        Returns:
+            PullListSeries: The pull list series entry.
+
+        Raises:
+            ApiError: If the series is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> entry = session.pull_list_add_series(42)
+            >>> print(entry.series.display_name)
+        """
+        url = self.api_url.format("/".join([ResourceEndpoint.PULL_LIST, "series", "add"]))
+        resp = self._request_data("POST", url, params={"series_id": series_id})
+        return self._validate_response(resp, PullListSeries)
+
+    def pull_list_remove_series(self, series_pk: int) -> None:
+        """Remove a series from the authenticated user's pull list.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            series_pk: The unique identifier of the pull list series entry to remove.
+
+        Raises:
+            ApiError: If the entry is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> session.pull_list_remove_series(1)
+        """
+        self._send_void("DELETE", [ResourceEndpoint.PULL_LIST, "series", series_pk, "remove"])
+
+    # Wish list methods
+    def wish_list(self) -> WishList:
+        """Retrieve the authenticated user's wish list.
+
+        Note: This endpoint requires authentication.
+
+        Returns:
+            A WishList object.
+
+        Raises:
+            ApiError: If there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> wl = session.wish_list()
+            >>> print(f"Items: {wl.item_count}")
+        """
+        results = self._list_resources(ResourceEndpoint.WISH_LIST, None, WishList)
+        return results[0]
 
     def wish_list_items(self, params: dict[str, str | int] | None = None) -> list[WishListItemList]:
         """Retrieve wish list items for the authenticated user.

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -49,7 +49,7 @@ from mokkari.schemas.issue import (
     IssuePostResponse,
 )
 from mokkari.schemas.publisher import Publisher, PublisherPost
-from mokkari.schemas.pull_list import PullListIssue, PullListRead, PullListSeries
+from mokkari.schemas.pull_list import PullListAddSeries, PullListIssue, PullListRead, PullListSeries
 from mokkari.schemas.reading_list import ReadingListItem, ReadingListList, ReadingListRead
 from mokkari.schemas.series import BaseSeries, Series, SeriesPost, SeriesPostResponse
 from mokkari.schemas.team import Team, TeamPost, TeamPostResponse
@@ -1655,9 +1655,12 @@ class Session:
             >>> entry = session.pull_list_add_series(42)
             >>> print(entry.series.display_name)
         """
-        url = self.api_url.format("/".join([ResourceEndpoint.PULL_LIST, "series", "add"]))
-        resp = self._request_data("POST", url, params={"series_id": series_id})
-        return self._validate_response(resp, PullListSeries)
+        return self._handle_write_request(
+            "POST",
+            [ResourceEndpoint.PULL_LIST, "series", "add"],
+            PullListAddSeries(series_id=series_id),
+            PullListSeries,
+        )
 
     def pull_list_remove_series(self, series_pk: int) -> None:
         """Remove a series from the authenticated user's pull list.

--- a/tests/test_pull_list_schemas.py
+++ b/tests/test_pull_list_schemas.py
@@ -1,0 +1,142 @@
+"""Tests for the pull_list module."""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from mokkari.schemas.pull_list import PullListIssue, PullListRead, PullListSeries
+
+
+@pytest.fixture
+def basic_series_data():
+    """Sample basic series data (IssueListSeries)."""
+    return {"name": "Batman", "volume": 1, "year_began": 1940}
+
+
+@pytest.fixture
+def base_series_data():
+    """Sample base series data (SeriesList)."""
+    return {
+        "id": 10,
+        "series": "Batman",
+        "year_began": 1940,
+        "year_end": None,
+        "volume": 1,
+        "issue_count": 100,
+        "modified": "2024-01-01T12:00:00Z",
+    }
+
+
+# PullListRead tests
+def test_pull_list_read_valid_data():
+    """Test PullListRead model with valid data."""
+    data = {
+        "id": 1,
+        "series_count": 5,
+        "series_url": "https://metron.cloud/api/pull_list/1/series/",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    pl = PullListRead(**data)
+    assert pl.id == 1
+    assert pl.series_count == 5
+    assert pl.series_url == "https://metron.cloud/api/pull_list/1/series/"
+    assert pl.modified.year == 2024
+
+
+def test_pull_list_read_missing_required_field():
+    """Test PullListRead model with missing required field."""
+    with pytest.raises(ValidationError):
+        PullListRead(id=1, series_count=5, modified="2024-01-01T12:00:00Z")  # type: ignore
+
+
+# PullListIssue tests
+def test_pull_list_issue_valid_data(basic_series_data):
+    """Test PullListIssue model with valid data."""
+    data = {
+        "id": 100,
+        "series": basic_series_data,
+        "number": "1",
+        "issue": "Batman #1",
+        "cover_date": "2024-01-01",
+        "store_date": "2023-12-27",
+        "image": "https://metron.cloud/media/issue/batman-1.jpg",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    issue = PullListIssue(**data)
+    assert issue.id == 100
+    assert issue.series.name == "Batman"
+    assert issue.series.volume == 1
+    assert issue.series.year_began == 1940
+    assert issue.number == "1"
+    assert issue.issue == "Batman #1"
+    assert issue.cover_date.year == 2024
+    assert issue.store_date is not None
+    assert issue.modified.year == 2024
+
+
+def test_pull_list_issue_optional_fields(basic_series_data):
+    """Test PullListIssue with optional fields omitted."""
+    data = {
+        "id": 100,
+        "series": basic_series_data,
+        "number": "1",
+        "issue": "Batman #1",
+        "cover_date": "2024-01-01",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    issue = PullListIssue(**data)
+    assert issue.store_date is None
+    assert issue.image is None
+
+
+def test_pull_list_issue_missing_required_field(basic_series_data):
+    """Test PullListIssue with missing required field."""
+    with pytest.raises(ValidationError):
+        PullListIssue(id=100, series=basic_series_data)  # type: ignore
+
+
+# PullListSeries tests
+def test_pull_list_series_valid_data(base_series_data):
+    """Test PullListSeries model with valid data."""
+    data = {
+        "id": 1,
+        "series": base_series_data,
+        "added_on": "2024-06-01T10:00:00Z",
+    }
+    entry = PullListSeries(**data)
+    assert entry.id == 1
+    assert entry.series.display_name == "Batman"
+    assert entry.series.year_began == 1940
+    assert entry.series.issue_count == 100
+    assert isinstance(entry.added_on, datetime)
+    assert entry.added_on.year == 2024
+
+
+def test_pull_list_series_missing_required_field(base_series_data):
+    """Test PullListSeries with missing required field."""
+    with pytest.raises(ValidationError):
+        PullListSeries(id=1, series=base_series_data)  # type: ignore
+
+
+def test_pull_list_series_year_end_none(base_series_data):
+    """Test PullListSeries with ongoing series (year_end=None)."""
+    data = {
+        "id": 2,
+        "series": base_series_data,
+        "added_on": "2024-06-01T10:00:00Z",
+    }
+    entry = PullListSeries(**data)
+    assert entry.series.year_end is None
+
+
+def test_pull_list_series_with_year_end(base_series_data):
+    """Test PullListSeries with a completed series."""
+    base_series_data["year_end"] = 1986
+    data = {
+        "id": 3,
+        "series": base_series_data,
+        "added_on": "2024-06-01T10:00:00Z",
+    }
+    entry = PullListSeries(**data)
+    assert entry.series.year_end == 1986

--- a/tests/test_pull_list_schemas.py
+++ b/tests/test_pull_list_schemas.py
@@ -5,27 +5,18 @@ from datetime import datetime
 import pytest
 from pydantic import ValidationError
 
-from mokkari.schemas.pull_list import PullListIssue, PullListRead, PullListSeries
+from mokkari.schemas.pull_list import (
+    PullListIssue,
+    PullListRead,
+    PullListSeries,
+    PullListSeriesDetail,
+)
 
 
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data (IssueListSeries)."""
     return {"name": "Batman", "volume": 1, "year_began": 1940}
-
-
-@pytest.fixture
-def base_series_data():
-    """Sample base series data (SeriesList)."""
-    return {
-        "id": 10,
-        "series": "Batman",
-        "year_began": 1940,
-        "year_end": None,
-        "volume": 1,
-        "issue_count": 100,
-        "modified": "2024-01-01T12:00:00Z",
-    }
 
 
 # PullListRead tests
@@ -96,47 +87,74 @@ def test_pull_list_issue_missing_required_field(basic_series_data):
         PullListIssue(id=100, series=basic_series_data)  # type: ignore
 
 
-# PullListSeries tests
-def test_pull_list_series_valid_data(base_series_data):
-    """Test PullListSeries model with valid data."""
+# PullListSeriesDetail tests
+def test_pull_list_series_detail_valid_data():
+    """Test PullListSeriesDetail model with valid data."""
     data = {
         "id": 1,
-        "series": base_series_data,
-        "added_on": "2024-06-01T10:00:00Z",
+        "series": "Death of the Inhumans (2018)",
+        "year_began": 2018,
+        "year_end": 2018,
+        "volume": 1,
+        "modified": "2024-12-27T11:29:08.281134-05:00",
     }
-    entry = PullListSeries(**data)
-    assert entry.id == 1
-    assert entry.series.display_name == "Batman"
-    assert entry.series.year_began == 1940
-    assert entry.series.issue_count == 100
-    assert isinstance(entry.added_on, datetime)
-    assert entry.added_on.year == 2024
+    detail = PullListSeriesDetail(**data)
+    assert detail.id == 1
+    assert detail.name == "Death of the Inhumans (2018)"
+    assert detail.year_began == 2018
+    assert detail.year_end == 2018
+    assert detail.volume == 1
 
 
-def test_pull_list_series_missing_required_field(base_series_data):
-    """Test PullListSeries with missing required field."""
-    with pytest.raises(ValidationError):
-        PullListSeries(id=1, series=base_series_data)  # type: ignore
-
-
-def test_pull_list_series_year_end_none(base_series_data):
-    """Test PullListSeries with ongoing series (year_end=None)."""
+def test_pull_list_series_detail_ongoing_series():
+    """Test PullListSeriesDetail with an ongoing series (year_end=None)."""
     data = {
         "id": 2,
-        "series": base_series_data,
-        "added_on": "2024-06-01T10:00:00Z",
+        "series": "Batman",
+        "year_began": 1940,
+        "year_end": None,
+        "volume": 1,
+        "modified": "2024-01-01T12:00:00Z",
     }
-    entry = PullListSeries(**data)
-    assert entry.series.year_end is None
+    detail = PullListSeriesDetail(**data)
+    assert detail.year_end is None
 
 
-def test_pull_list_series_with_year_end(base_series_data):
-    """Test PullListSeries with a completed series."""
-    base_series_data["year_end"] = 1986
+# PullListSeries tests
+def test_pull_list_series_valid_data():
+    """Test PullListSeries model with valid data."""
     data = {
-        "id": 3,
-        "series": base_series_data,
-        "added_on": "2024-06-01T10:00:00Z",
+        "id": 6,
+        "series": {
+            "id": 1,
+            "series": "Death of the Inhumans (2018)",
+            "year_began": 2018,
+            "year_end": 2018,
+            "volume": 1,
+            "modified": "2024-12-27T11:29:08.281134-05:00",
+        },
+        "added_on": "2026-05-20T16:46:36.044123-04:00",
     }
     entry = PullListSeries(**data)
-    assert entry.series.year_end == 1986
+    assert entry.id == 6
+    assert entry.series.id == 1
+    assert entry.series.name == "Death of the Inhumans (2018)"
+    assert entry.series.year_began == 2018
+    assert entry.series.year_end == 2018
+    assert isinstance(entry.added_on, datetime)
+    assert entry.added_on.year == 2026
+
+
+def test_pull_list_series_missing_required_field():
+    """Test PullListSeries with missing required field."""
+    with pytest.raises(ValidationError):
+        PullListSeries(
+            id=1,
+            series={
+                "id": 10,
+                "series": "Batman",
+                "year_began": 1940,
+                "volume": 1,
+                "modified": "2024-01-01T12:00:00Z",
+            },
+        )  # type: ignore

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2457,34 +2457,6 @@ def test_default_bucket_shared_across_sessions() -> None:
 def test_wish_list(session: Session) -> None:
     # Arrange
     resp = {
-        "id": 1,
-        "item_count": 5,
-        "items_url": "https://metron.cloud/api/wish_list/1/items/",
-        "modified": "2024-01-01T12:00:00Z",
-    }
-    with (
-        patch.object(session, "_get", return_value=resp),
-        patch(
-            "mokkari.session.TypeAdapter.validate_python",
-            return_value=WishList(
-                id=1,
-                item_count=5,
-                items_url="https://metron.cloud/api/wish_list/1/items/",
-                modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
-            ),
-        ),
-    ):
-        # Act
-        result = session.wish_list(1)
-        # Assert
-        assert isinstance(result, WishList)
-        assert result.id == 1
-        assert result.item_count == 5
-
-
-def test_wish_lists_list(session: Session) -> None:
-    # Arrange
-    resp = {
         "results": [
             {
                 "id": 1,
@@ -2510,12 +2482,11 @@ def test_wish_lists_list(session: Session) -> None:
         ),
     ):
         # Act
-        result = session.wish_lists_list()
+        result = session.wish_list()
         # Assert
-        assert isinstance(result, list)
-        assert len(result) == 1
-        assert result[0].id == 1
-        assert result[0].item_count == 5
+        assert isinstance(result, WishList)
+        assert result.id == 1
+        assert result.item_count == 5
 
 
 def test_wish_list_items(session: Session) -> None:


### PR DESCRIPTION
## Summary

Add support for the Metron pull list API endpoints.

### New schema (`mokkari/schemas/pull_list.py`)

- `PullListRead` — the authenticated user's pull list
- `PullListIssue` — an issue belonging to a pull list series
- `PullListSeries` — a series entry on the pull list

### New session methods

- `pull_list()` — retrieve the authenticated user's pull list
- `pull_list_issues()` — get issues for pull list series, with optional `store_date_after`/`store_date_before` filtering
- `pull_list_series()` — get series on the pull list
- `pull_list_add_series(series_id)` — add a series to the pull list
- `pull_list_remove_series(series_pk)` — remove a series from the pull list

## Changes to existing behaviour

`pull_list()` and `wish_list()` now return the authenticated user's list directly (via the list endpoint) rather than requiring the caller to supply an ID. The previous `pull_list(id)` / `pull_lists_list()` and `wish_list(id)` / `wish_lists_list()` signatures have been removed.
