### PR TITLE
Add series id to issue list responses

### DIFF
--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -99,14 +99,16 @@ class CreditPostResponse(CreditPost):
 
 
 class BasicSeries(BaseModel):
-    """A class representing a basic series with name, volume, and year began.
+    """A class representing a basic series with id, name, volume, and year began.
 
     Attributes:
+        id (int): The unique identifier of the series.
         name (str): The name of the series.
         volume (int): The volume of the series.
         year_began (int): The year the series began.
     """
 
+    id: int
     name: str
     volume: int
     year_began: int

--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -75,7 +75,7 @@ def test_arc_issue_list(talker: Session) -> None:
         "results": [
             {
                 "id": 6798,
-                "series": {"name": "Batman", "volume": 1, "year_began": 2011},
+                "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 2011},
                 "number": "1",
                 "issue": "Batman (2011) #1",
                 "cover_date": "2011-11-01",
@@ -84,7 +84,7 @@ def test_arc_issue_list(talker: Session) -> None:
             },
             {
                 "id": 6799,
-                "series": {"name": "Batman", "volume": 1, "year_began": 2011},
+                "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 2011},
                 "number": "2",
                 "issue": "Batman (2011) #2",
                 "cover_date": "2011-12-01",

--- a/tests/test_characters.py
+++ b/tests/test_characters.py
@@ -101,7 +101,7 @@ def test_character_issue_list(talker: Session) -> None:
         "results": [
             {
                 "id": 258,
-                "series": {"name": "Fantastic Four", "volume": 1, "year_began": 1961},
+                "series": {"id": 1, "name": "Fantastic Four", "volume": 1, "year_began": 1961},
                 "number": "45",
                 "issue": "Fantastic Four (1961) #45",
                 "cover_date": "1965-12-01",
@@ -110,7 +110,7 @@ def test_character_issue_list(talker: Session) -> None:
             },
             {
                 "id": 259,
-                "series": {"name": "Fantastic Four", "volume": 1, "year_began": 1961},
+                "series": {"id": 1, "name": "Fantastic Four", "volume": 1, "year_began": 1961},
                 "number": "46",
                 "issue": "Fantastic Four (1961) #46",
                 "cover_date": "1966-01-01",

--- a/tests/test_collection_schemas.py
+++ b/tests/test_collection_schemas.py
@@ -35,7 +35,7 @@ def user_data():
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data."""
-    return {"name": "Batman", "volume": 1, "year_began": 1940}
+    return {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940}
 
 
 @pytest.fixture

--- a/tests/test_issue_schemas.py
+++ b/tests/test_issue_schemas.py
@@ -31,7 +31,7 @@ def generic_item_data():
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data."""
-    return {"name": "Batman", "volume": 1, "year_began": 1940}
+    return {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940}
 
 
 @pytest.fixture
@@ -165,6 +165,7 @@ def test_credit_post_response_creation():
 def test_basic_series_creation(basic_series_data):
     """Test creating a BasicSeries."""
     series = BasicSeries(**basic_series_data)
+    assert series.id == 1
     assert series.name == "Batman"
     assert series.volume == 1
     assert series.year_began == 1940
@@ -173,25 +174,28 @@ def test_basic_series_creation(basic_series_data):
 def test_basic_series_validation_missing_fields():
     """Test BasicSeries validation with missing required fields."""
     with pytest.raises(ValidationError):
-        BasicSeries(name="Batman", volume=1)  # Missing year_began
+        BasicSeries(id=1, name="Batman", volume=1)  # Missing year_began
 
     with pytest.raises(ValidationError):
-        BasicSeries(volume=1, year_began=1940)  # Missing name
+        BasicSeries(id=1, volume=1, year_began=1940)  # Missing name
 
     with pytest.raises(ValidationError):
-        BasicSeries(name="Batman", year_began=1940)  # Missing volume
+        BasicSeries(id=1, name="Batman", year_began=1940)  # Missing volume
+
+    with pytest.raises(ValidationError):
+        BasicSeries(name="Batman", volume=1, year_began=1940)  # Missing id
 
 
 def test_basic_series_validation_invalid_types():
     """Test BasicSeries validation with invalid types."""
     with pytest.raises(ValidationError):
-        BasicSeries(name=123, volume=1, year_began=1940)
+        BasicSeries(id=1, name=123, volume=1, year_began=1940)
 
     with pytest.raises(ValidationError):
-        BasicSeries(name="Batman", volume="not_int", year_began=1940)
+        BasicSeries(id=1, name="Batman", volume="not_int", year_began=1940)
 
     with pytest.raises(ValidationError):
-        BasicSeries(name="Batman", volume=1, year_began="not_int")
+        BasicSeries(id=1, name="Batman", volume=1, year_began="not_int")
 
 
 # IssueSeries model tests
@@ -299,7 +303,7 @@ def test_base_issue_field_alias():
         "cover_date": "2023-01-01",
         "modified": "2023-01-01T12:00:00Z",
         "issue": "Test Issue Name",
-        "series": {"name": "Test Series", "volume": 1, "year_began": 2020},
+        "series": {"id": 1, "name": "Test Series", "volume": 1, "year_began": 2020},
     }
     issue = BaseIssue(**data)
     assert issue.issue_name == "Test Issue Name"

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -293,7 +293,7 @@ def test_issueslist(talker: Session) -> None:
         "results": [
             {
                 "id": 6730,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 2011},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 2011},
                 "number": "1",
                 "issue": "Action Comics (2011) #1",
                 "cover_date": "2011-11-01",
@@ -302,7 +302,7 @@ def test_issueslist(talker: Session) -> None:
             },
             {
                 "id": 6731,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 2011},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 2011},
                 "number": "2",
                 "issue": "Action Comics (2011) #2",
                 "cover_date": "2011-12-01",
@@ -311,7 +311,7 @@ def test_issueslist(talker: Session) -> None:
             },
             {
                 "id": 6732,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 2011},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 2011},
                 "number": "3",
                 "issue": "Action Comics (2011) #3",
                 "cover_date": "2012-01-01",
@@ -340,7 +340,7 @@ def test_issueslist_with_params(talker: Session) -> None:
         "results": [
             {
                 "id": 100,
-                "series": {"name": "Kang", "volume": 1, "year_began": 2021},
+                "series": {"id": 1, "name": "Kang", "volume": 1, "year_began": 2021},
                 "number": "1",
                 "issue": "Kang The Conqueror (2021) #1",
                 "cover_date": "2021-10-01",
@@ -349,7 +349,7 @@ def test_issueslist_with_params(talker: Session) -> None:
             },
             {
                 "id": 101,
-                "series": {"name": "Kang", "volume": 1, "year_began": 2021},
+                "series": {"id": 1, "name": "Kang", "volume": 1, "year_began": 2021},
                 "number": "2",
                 "issue": "Kang The Conqueror (2021) #2",
                 "cover_date": "2021-11-01",
@@ -678,7 +678,7 @@ def test_multi_page_results(talker: Session) -> None:
         "results": [
             {
                 "id": 1,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 1938},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 1938},
                 "number": "1",
                 "issue": "Action Comics (1938) #1",
                 "cover_date": "1938-06-01",
@@ -687,7 +687,7 @@ def test_multi_page_results(talker: Session) -> None:
             },
             {
                 "id": 2,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 1938},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 1938},
                 "number": "2",
                 "issue": "Action Comics (1938) #2",
                 "cover_date": "1938-07-01",
@@ -703,7 +703,7 @@ def test_multi_page_results(talker: Session) -> None:
         "results": [
             {
                 "id": 903,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 1938},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 1938},
                 "number": "903",
                 "issue": "Action Comics (1938) #903",
                 "cover_date": "2011-09-01",
@@ -712,7 +712,7 @@ def test_multi_page_results(talker: Session) -> None:
             },
             {
                 "id": 904,
-                "series": {"name": "Action Comics", "volume": 1, "year_began": 1938},
+                "series": {"id": 1, "name": "Action Comics", "volume": 1, "year_began": 1938},
                 "number": "904",
                 "issue": "Action Comics (1938) #904",
                 "cover_date": "2011-10-01",

--- a/tests/test_pull_list_schemas.py
+++ b/tests/test_pull_list_schemas.py
@@ -16,7 +16,7 @@ from mokkari.schemas.pull_list import (
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data (IssueListSeries)."""
-    return {"name": "Batman", "volume": 1, "year_began": 1940}
+    return {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940}
 
 
 # PullListRead tests
@@ -56,6 +56,7 @@ def test_pull_list_issue_valid_data(basic_series_data):
     }
     issue = PullListIssue(**data)
     assert issue.id == 100
+    assert issue.series.id == 1
     assert issue.series.name == "Batman"
     assert issue.series.volume == 1
     assert issue.series.year_began == 1940

--- a/tests/test_reading_list_schemas.py
+++ b/tests/test_reading_list_schemas.py
@@ -25,7 +25,7 @@ def user_data():
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data."""
-    return {"name": "Batman", "volume": 1, "year_began": 1940}
+    return {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940}
 
 
 @pytest.fixture

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -155,7 +155,12 @@ def test_series_issues_list(talker: Session) -> None:
         "results": [
             {
                 "id": 1,
-                "series": {"name": "Death of the Inhumans", "volume": 1, "year_began": 2018},
+                "series": {
+                    "id": 1,
+                    "name": "Death of the Inhumans",
+                    "volume": 1,
+                    "year_began": 2018,
+                },
                 "number": "1",
                 "issue": "Death of the Inhumans (2018) #1",
                 "cover_date": "2018-09-01",
@@ -166,7 +171,12 @@ def test_series_issues_list(talker: Session) -> None:
             },
             {
                 "id": 2,
-                "series": {"name": "Death of the Inhumans", "volume": 1, "year_began": 2018},
+                "series": {
+                    "id": 1,
+                    "name": "Death of the Inhumans",
+                    "volume": 1,
+                    "year_began": 2018,
+                },
                 "number": "2",
                 "issue": "Death of the Inhumans (2018) #2",
                 "cover_date": "2018-10-01",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -504,7 +504,7 @@ def test_character_issues_list_happy_path(session: Session) -> None:
                     store_date=None,
                     modified=datetime.datetime.now(),
                     issue="",
-                    series=BasicSeries(name="Series 1", volume=1, year_began=2025),
+                    series=BasicSeries(id=1, name="Series 1", volume=1, year_began=2025),
                 ),
             ],
         ),
@@ -697,7 +697,7 @@ def test_team_issues_list(session: Session) -> None:
                     store_date=None,
                     modified=datetime.datetime.now(),
                     issue="",
-                    series=BasicSeries(name="Series 1", volume=1, year_began=2025),
+                    series=BasicSeries(id=1, name="Series 1", volume=1, year_began=2025),
                 ),
             ],
         ),
@@ -807,7 +807,7 @@ def test_arc_issues_list(session: Session) -> None:
                     store_date=None,
                     modified=datetime.datetime.now(),
                     issue="",
-                    series=BasicSeries(name="Series 1", volume=1, year_began=2025),
+                    series=BasicSeries(id=1, name="Series 1", volume=1, year_began=2025),
                 ),
             ],
         ),
@@ -1007,7 +1007,7 @@ def test_issues_list(session: Session) -> None:
                     issue="Issue #1",
                     number="1",
                     modified=datetime.datetime.now(),
-                    series=BasicSeries(name="Foo Bar", volume=1, year_began=2025),
+                    series=BasicSeries(id=1, name="Foo Bar", volume=1, year_began=2025),
                     cover_date=datetime.date(2025, 5, 1),
                 )
             ],
@@ -1341,7 +1341,7 @@ def test_reading_list_items(session: Session) -> None:
                 "id": 1,
                 "issue": {
                     "id": 100,
-                    "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                    "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
                     "number": "1",
                     "cover_date": "2023-01-01",
                     "modified": "2023-01-01T12:00:00Z",
@@ -1360,7 +1360,7 @@ def test_reading_list_items(session: Session) -> None:
                     id=1,
                     issue=ReadingListIssue(
                         id=100,
-                        series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                        series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                         number="1",
                         cover_date=datetime.date(2023, 1, 1),
                         modified=datetime.datetime.now(),
@@ -1387,7 +1387,7 @@ def test_collection(session: Session) -> None:
         "user": {"id": 1, "username": "testuser"},
         "issue": {
             "id": 100,
-            "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+            "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
             "number": "1",
             "cover_date": "2023-01-01",
             "modified": "2023-01-01T12:00:00Z",
@@ -1417,7 +1417,7 @@ def test_collection(session: Session) -> None:
                 user=User(id=1, username="testuser"),
                 issue=CollectionIssue(
                     id=100,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="1",
                     cover_date=datetime.date(2023, 1, 1),
                     modified=datetime.datetime.now(),
@@ -1457,7 +1457,7 @@ def test_collections_list(session: Session) -> None:
                 "user": {"id": 1, "username": "testuser"},
                 "issue": {
                     "id": 100,
-                    "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                    "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
                     "number": "1",
                     "cover_date": "2023-01-01",
                     "modified": "2023-01-01T12:00:00Z",
@@ -1481,7 +1481,7 @@ def test_collections_list(session: Session) -> None:
                     user=User(id=1, username="testuser"),
                     issue=CollectionIssue(
                         id=100,
-                        series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                        series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                         number="1",
                         cover_date=datetime.date(2023, 1, 1),
                         modified=datetime.datetime.now(),
@@ -1513,7 +1513,7 @@ def test_collections_list_with_params(session: Session) -> None:
                 "user": {"id": 1, "username": "testuser"},
                 "issue": {
                     "id": 101,
-                    "series": {"name": "Superman", "volume": 1, "year_began": 1938},
+                    "series": {"id": 1, "name": "Superman", "volume": 1, "year_began": 1938},
                     "number": "1",
                     "cover_date": "2023-02-01",
                     "modified": "2023-02-01T12:00:00Z",
@@ -1537,7 +1537,7 @@ def test_collections_list_with_params(session: Session) -> None:
                     user=User(id=1, username="testuser"),
                     issue=CollectionIssue(
                         id=101,
-                        series=BasicSeries(name="Superman", volume=1, year_began=1938),
+                        series=BasicSeries(id=1, name="Superman", volume=1, year_began=1938),
                         number="1",
                         cover_date=datetime.date(2023, 2, 1),
                         modified=datetime.datetime.now(),
@@ -1566,14 +1566,14 @@ def test_collection_missing_issues(session: Session) -> None:
         "results": [
             {
                 "id": 200,
-                "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
                 "number": "2",
                 "cover_date": "2023-02-01",
                 "store_date": "2023-01-15",
             },
             {
                 "id": 201,
-                "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
                 "number": "3",
                 "cover_date": "2023-03-01",
             },
@@ -1587,14 +1587,14 @@ def test_collection_missing_issues(session: Session) -> None:
             return_value=[
                 MissingIssue(
                     id=200,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="2",
                     cover_date=datetime.date(2023, 2, 1),
                     store_date=datetime.date(2023, 1, 15),
                 ),
                 MissingIssue(
                     id=201,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="3",
                     cover_date=datetime.date(2023, 3, 1),
                 ),
@@ -1736,7 +1736,7 @@ def test_collection_scrobble(session: Session) -> None:
         "id": 100,
         "issue": {
             "id": 1,
-            "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+            "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
             "number": "1",
             "cover_date": "2024-01-01",
             "store_date": "2023-12-15",
@@ -1756,7 +1756,7 @@ def test_collection_scrobble(session: Session) -> None:
                 id=100,
                 issue=CollectionIssue(
                     id=1,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="1",
                     cover_date=datetime.date(2024, 1, 1),
                     store_date=datetime.date(2023, 12, 15),
@@ -1788,7 +1788,7 @@ def test_collection_scrobble_minimal(session: Session) -> None:
         "id": 100,
         "issue": {
             "id": 1,
-            "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+            "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
             "number": "1",
             "cover_date": "2024-01-01",
             "modified": "2024-01-01T12:00:00Z",
@@ -1805,7 +1805,7 @@ def test_collection_scrobble_minimal(session: Session) -> None:
                 id=100,
                 issue=CollectionIssue(
                     id=1,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="1",
                     cover_date=datetime.date(2024, 1, 1),
                     modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
@@ -2497,7 +2497,7 @@ def test_wish_list_items(session: Session) -> None:
                 "id": 10,
                 "issue": {
                     "id": 1,
-                    "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+                    "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
                     "number": "1",
                     "cover_date": "2024-01-01",
                     "modified": "2024-01-01T12:00:00Z",
@@ -2518,7 +2518,7 @@ def test_wish_list_items(session: Session) -> None:
                     id=10,
                     issue=CollectionIssue(
                         id=1,
-                        series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                        series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                         number="1",
                         cover_date=datetime.date(2024, 1, 1),
                         modified=datetime.datetime(
@@ -2548,7 +2548,7 @@ def test_wish_list_add_item(session: Session) -> None:
         "id": 10,
         "issue": {
             "id": 1,
-            "series": {"name": "Batman", "volume": 1, "year_began": 1940},
+            "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
             "number": "1",
             "cover_date": "2024-01-01",
             "modified": "2024-01-01T12:00:00Z",
@@ -2568,7 +2568,7 @@ def test_wish_list_add_item(session: Session) -> None:
                 id=10,
                 issue=CollectionIssue(
                     id=1,
-                    series=BasicSeries(name="Batman", volume=1, year_began=1940),
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
                     number="1",
                     cover_date=datetime.date(2024, 1, 1),
                     modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -72,7 +72,7 @@ def test_team_issue_list(talker: Session) -> None:
         "results": [
             {
                 "id": 258,
-                "series": {"name": "Fantastic Four", "volume": 1, "year_began": 1961},
+                "series": {"id": 1, "name": "Fantastic Four", "volume": 1, "year_began": 1961},
                 "number": "45",
                 "issue": "Fantastic Four (1961) #45",
                 "cover_date": "1965-12-01",
@@ -81,7 +81,7 @@ def test_team_issue_list(talker: Session) -> None:
             },
             {
                 "id": 259,
-                "series": {"name": "Fantastic Four", "volume": 1, "year_began": 1961},
+                "series": {"id": 1, "name": "Fantastic Four", "volume": 1, "year_began": 1961},
                 "number": "46",
                 "issue": "Fantastic Four (1961) #46",
                 "cover_date": "1966-01-01",

--- a/tests/test_wish_list_schemas.py
+++ b/tests/test_wish_list_schemas.py
@@ -20,7 +20,7 @@ from mokkari.schemas.wish_list import (
 @pytest.fixture
 def basic_series_data():
     """Sample basic series data."""
-    return {"name": "Batman", "volume": 1, "year_began": 1940}
+    return {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940}
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Add `id` field to `BasicSeries` to match the Metron API's `IssueListSeriesSerializer`, which now returns the series id alongside name, volume, and year_began (metron-project/metron#488).
- `BasicSeries` is shared across the issue, collection, pull list, and reading list schemas, so this single change propagates the new field everywhere it's used.
- Update fixtures and mocked API responses in tests to include the series `id`, and add a validation test asserting `id` is required.
