### PR TITLE
Add collection_patch method for updating collection item ratings

### DIFF
--- a/mokkari/schemas/collection.py
+++ b/mokkari/schemas/collection.py
@@ -16,6 +16,8 @@ This module provides the following classes:
 - CollectionStats
 - ScrobbleRequest
 - ScrobbleResponse
+- CollectionUpdate
+- CollectionUpdateResponse
 """
 
 __all__ = [
@@ -25,6 +27,8 @@ __all__ = [
     "CollectionList",
     "CollectionRead",
     "CollectionStats",
+    "CollectionUpdate",
+    "CollectionUpdateResponse",
     "Grade",
     "GradingCompany",
     "MissingIssue",
@@ -389,4 +393,28 @@ class ScrobbleResponse(BaseModel):
     date_read: datetime | None = None
     rating: int | None = None
     created: bool
+    modified: datetime
+
+
+class CollectionUpdate(BaseModel):
+    """A data model representing a request to update a collection item's rating.
+
+    Attributes:
+        rating (int, optional): Star rating (1-5) for this issue.
+    """
+
+    rating: int | None = Field(None, ge=1, le=5)
+
+
+class CollectionUpdateResponse(BaseModel):
+    """A data model representing the response from a collection update operation.
+
+    Attributes:
+        id (int): The unique identifier of the collection item.
+        rating (int, optional): Star rating (1-5) for this issue.
+        modified (datetime): The date and time when the collection item was last modified.
+    """
+
+    id: int
+    rating: int | None = None
     modified: datetime

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -32,6 +32,8 @@ from mokkari.schemas.collection import (
     CollectionList,
     CollectionRead,
     CollectionStats,
+    CollectionUpdate,
+    CollectionUpdateResponse,
     MissingIssue,
     MissingSeries,
     ScrobbleRequest,
@@ -1560,6 +1562,34 @@ class Session:
         """
         return self._handle_write_request(
             "POST", [ResourceEndpoint.COLLECTION, "scrobble"], data, ScrobbleResponse
+        )
+
+    def collection_patch(self, _id: int, data: CollectionUpdate) -> CollectionUpdateResponse:
+        """Update the rating of an existing collection item.
+
+        Note: Users can only update items in their own collection. Only the rating field can be updated; read-tracking
+        (is_read/date_read) is handled exclusively through the scrobble action.
+
+        Args:
+            _id: The unique identifier for the collection item to update.
+            data: CollectionUpdate object containing the updated rating.
+
+        Returns:
+            CollectionUpdateResponse: The updated collection item's id, rating, and
+                                       modified timestamp.
+
+        Raises:
+            ApiError: If update fails or if user lacks permissions.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> update_data = CollectionUpdate(rating=4)
+            >>> result = session.collection_patch(1, update_data)
+            >>> print(f"Rating updated to: {result.rating}")
+        """
+        return self._patch_resource(
+            ResourceEndpoint.COLLECTION, _id, data, CollectionUpdateResponse
         )
 
     # Pull list methods

--- a/tests/test_collection_schemas.py
+++ b/tests/test_collection_schemas.py
@@ -13,6 +13,8 @@ from mokkari.schemas.collection import (
     CollectionList,
     CollectionRead,
     CollectionStats,
+    CollectionUpdate,
+    CollectionUpdateResponse,
     Grade,
     GradingCompany,
     MissingIssue,
@@ -400,7 +402,7 @@ def test_scrobble_request_valid_data():
 def test_scrobble_request_minimal_data():
     """Test ScrobbleRequest with only required field."""
     data = {"issue_id": 1}
-    scrobble = ScrobbleRequest(**data)
+    scrobble = ScrobbleRequest(**data)  # type: ignore
     assert scrobble.issue_id == 1
     assert scrobble.date_read is None
     assert scrobble.rating is None
@@ -409,7 +411,7 @@ def test_scrobble_request_minimal_data():
 def test_scrobble_request_with_rating_only():
     """Test ScrobbleRequest with issue_id and rating."""
     data = {"issue_id": 42, "rating": 3}
-    scrobble = ScrobbleRequest(**data)
+    scrobble = ScrobbleRequest(**data)  # type: ignore
     assert scrobble.issue_id == 42
     assert scrobble.rating == 3
     assert scrobble.date_read is None
@@ -419,7 +421,7 @@ def test_scrobble_request_invalid_rating_too_low():
     """Test ScrobbleRequest with rating below minimum."""
     data = {"issue_id": 1, "rating": 0}
     with pytest.raises(ValidationError) as exc_info:
-        ScrobbleRequest(**data)
+        ScrobbleRequest(**data)  # type: ignore
     assert "rating" in str(exc_info.value)
 
 
@@ -427,7 +429,7 @@ def test_scrobble_request_invalid_rating_too_high():
     """Test ScrobbleRequest with rating above maximum."""
     data = {"issue_id": 1, "rating": 6}
     with pytest.raises(ValidationError) as exc_info:
-        ScrobbleRequest(**data)
+        ScrobbleRequest(**data)  # type: ignore
     assert "rating" in str(exc_info.value)
 
 
@@ -501,3 +503,53 @@ def test_scrobble_response_missing_required_fields(collection_issue_data):
     }
     with pytest.raises(ValidationError):
         ScrobbleResponse(**data)
+
+
+# CollectionUpdate tests
+def test_collection_update_valid_data():
+    """Test CollectionUpdate model with valid data."""
+    update = CollectionUpdate(rating=4)
+    assert update.rating == 4
+
+
+def test_collection_update_no_rating():
+    """Test CollectionUpdate with no rating provided."""
+    update = CollectionUpdate()  # type: ignore
+    assert update.rating is None
+
+
+def test_collection_update_invalid_rating_too_low():
+    """Test CollectionUpdate with rating below minimum."""
+    with pytest.raises(ValidationError) as exc_info:
+        CollectionUpdate(rating=0)
+    assert "rating" in str(exc_info.value)
+
+
+def test_collection_update_invalid_rating_too_high():
+    """Test CollectionUpdate with rating above maximum."""
+    with pytest.raises(ValidationError) as exc_info:
+        CollectionUpdate(rating=6)
+    assert "rating" in str(exc_info.value)
+
+
+# CollectionUpdateResponse tests
+def test_collection_update_response_valid_data():
+    """Test CollectionUpdateResponse model with valid data."""
+    data = {"id": 1, "rating": 4, "modified": "2024-01-20T14:30:00Z"}
+    response = CollectionUpdateResponse(**data)
+    assert response.id == 1
+    assert response.rating == 4
+    assert response.modified.year == 2024
+
+
+def test_collection_update_response_no_rating():
+    """Test CollectionUpdateResponse with no rating."""
+    data = {"id": 1, "modified": "2024-01-20T14:30:00Z"}
+    response = CollectionUpdateResponse(**data)
+    assert response.rating is None
+
+
+def test_collection_update_response_missing_required_fields():
+    """Test CollectionUpdateResponse with missing required fields."""
+    with pytest.raises(ValidationError):
+        CollectionUpdateResponse(rating=4)  # type: ignore

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,6 +25,8 @@ from mokkari.schemas.collection import (
     CollectionList,
     CollectionRead,
     CollectionStats,
+    CollectionUpdate,
+    CollectionUpdateResponse,
     MissingIssue,
     MissingSeries,
     ScrobbleRequest,
@@ -1825,6 +1827,34 @@ def test_collection_scrobble_minimal(session: Session) -> None:
         assert result.created is False
         assert result.date_read is None
         assert result.rating is None
+
+
+def test_collection_patch(session: Session) -> None:
+    # Arrange
+    data = CollectionUpdate(rating=4)
+    with (
+        patch.object(session, "_send", return_value={"id": 1, "rating": 4}),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=CollectionUpdateResponse(id=1, rating=4, modified=datetime.datetime.now()),
+        ),
+    ):
+        # Act
+        result = session.collection_patch(1, data)
+        # Assert
+        assert isinstance(result, CollectionUpdateResponse)
+        assert result.id == 1
+        assert result.rating == 4
+
+
+def test_collection_patch_api_error(session: Session) -> None:
+    # Arrange
+    data = CollectionUpdate(rating=4)
+    with (
+        patch.object(session, "_send", side_effect=exceptions.ApiError("fail")),
+        pytest.raises(exceptions.ApiError),
+    ):
+        session.collection_patch(1, data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add `collection_patch(_id, data)` to `Session`, mirroring the existing `creator_patch`/`series_patch` pattern via the generic `_patch_resource` helper.
- Add `CollectionUpdate` (request) and `CollectionUpdateResponse` (response) schemas in `mokkari/schemas/collection.py`. These are intentionally lean rather than reusing `CollectionRead`, since Metron's PATCH response only returns `id`, `rating`, and `modified` — validating against the full read schema would fail on missing required fields.
- Metron's PATCH endpoint only allows updating the `rating` field; read-tracking (`is_read`/`date_read`) is handled exclusively via the scrobble action, so `CollectionUpdate` only exposes `rating`.
