### PR TITLE
Use a stable per-user path for the default rate-limit bucket

### DIFF
--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -17,10 +17,12 @@ from datetime import datetime, timezone
 from email.utils import format_datetime as format_http_datetime
 from http import HTTPStatus
 from pathlib import Path
+from tempfile import gettempdir
 from typing import Any, Final, TypeVar, cast
 from urllib.parse import urlencode
 
 import requests
+from platformdirs import user_cache_dir
 from pydantic import TypeAdapter, ValidationError
 from pyrate_limiter import AbstractBucket, Duration, Limiter, Rate, RateItem, SQLiteBucket
 
@@ -85,12 +87,36 @@ _default_bucket_instance: SQLiteBucket | None = None
 _default_bucket_lock = threading.Lock()
 
 
+def _default_bucket_db_path() -> str:
+    """Return a stable, per-user path for the default rate-limit bucket.
+
+    Every process that shares this path shares the same request budget,
+    which is the point: a fresh timestamped temp file (pyrate_limiter's
+    own fallback) would give each process its own private 20/minute
+    allowance, letting the combined traffic from multiple processes blow
+    past Metron's actual server-side limit. platformdirs resolves to
+    $XDG_CACHE_HOME on Linux and the equivalent per-OS cache dir on macOS
+    and Windows.
+    """
+    cache_dir = Path(user_cache_dir("mokkari"))
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return str(cache_dir / "rate_limit.sqlite")
+    except OSError:
+        # Cache dir isn't writable (read-only home, restricted container, etc.)
+        # Fall back to a fixed name in the temp dir rather than pyrate_limiter's
+        # own timestamped default, so same-host processes still share a budget.
+        return str(Path(gettempdir()) / "mokkari_rate_limit.sqlite")
+
+
 def _default_bucket() -> SQLiteBucket:
     global _default_bucket_instance  # noqa: PLW0603
     if _default_bucket_instance is None:
         with _default_bucket_lock:
             if _default_bucket_instance is None:
-                _default_bucket_instance = SQLiteBucket.init_from_file(DEFAULT_RATES)
+                _default_bucket_instance = SQLiteBucket.init_from_file(
+                    DEFAULT_RATES, db_path=_default_bucket_db_path()
+                )
     return _default_bucket_instance
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,12 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
 ]
-dependencies = ["requests>=2.26.0", "pydantic>=2.10.3", "pyrate-limiter>=4"]
+dependencies = [
+  "requests>=2.26.0",
+  "pydantic>=2.10.3",
+  "pyrate-limiter>=4",
+  "platformdirs>=4",
+]
 
 [project.urls]
 Homepage = "https://github.com/Metron-Project/mokkari"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2484,6 +2484,45 @@ def test_default_bucket_shared_across_sessions() -> None:
         session_module._default_bucket_instance = original
 
 
+def test_default_bucket_db_path_uses_platform_cache_dir(tmp_path: Path) -> None:
+    """Test that the default bucket path lives under the platform cache dir.
+
+    A timestamped temp file (pyrate_limiter's own default) would give each
+    process its own private budget instead of one shared across processes.
+    """
+    with patch("mokkari.session.user_cache_dir", return_value=str(tmp_path / "mokkari")):
+        path = session_module._default_bucket_db_path()
+
+    assert path == str(tmp_path / "mokkari" / "rate_limit.sqlite")
+    assert (tmp_path / "mokkari").is_dir()
+
+
+def test_default_bucket_db_path_is_stable_across_calls(tmp_path: Path) -> None:
+    """Repeated calls must resolve to the same file so unrelated processes agree."""
+    with patch("mokkari.session.user_cache_dir", return_value=str(tmp_path / "mokkari")):
+        first = session_module._default_bucket_db_path()
+        second = session_module._default_bucket_db_path()
+
+    assert first == second
+
+
+def test_default_bucket_db_path_falls_back_when_cache_dir_unwritable(tmp_path: Path) -> None:
+    """Test the fallback when the platform cache dir can't be created.
+
+    It should use a fixed temp path rather than pyrate_limiter's own
+    timestamped default.
+    """
+    unwritable = tmp_path / "cache"
+    with (
+        patch("mokkari.session.user_cache_dir", return_value=str(unwritable)),
+        patch.object(Path, "mkdir", side_effect=OSError("read-only filesystem")),
+    ):
+        path = session_module._default_bucket_db_path()
+
+    assert path.endswith("mokkari_rate_limit.sqlite")
+    assert "pyrate_limiter_" not in path
+
+
 def test_wish_list(session: Session) -> None:
     # Arrange
     resp = {

--- a/uv.lock
+++ b/uv.lock
@@ -648,6 +648,7 @@ name = "mokkari"
 version = "3.29.0"
 source = { editable = "." }
 dependencies = [
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pyrate-limiter" },
     { name = "requests" },
@@ -682,6 +683,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "platformdirs", specifier = ">=4" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pyrate-limiter", specifier = ">=4" },
     { name = "requests", specifier = ">=2.26.0" },


### PR DESCRIPTION
## Summary
- The default `SQLiteBucket` previously relied on pyrate_limiter's own timestamped temp file, which gives each process its own private 20/minute allowance instead of one shared budget — letting combined traffic from multiple processes exceed Metron's actual server-side rate limit.
- `_default_bucket_db_path()` now resolves to a stable path under the platform's per-user cache dir (via `platformdirs`), falling back to a fixed temp-dir path if the cache dir isn't writable (read-only home, restricted container, etc.).
- Adds `platformdirs>=4` as a dependency.
