### PR TITLE
Replace pyrate_limiter with reactive X-RateLimit-* header tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,21 @@ print(asm_68.desc)
 
 ## Rate Limiting
 
-The API has rate limits of 20 requests per minute and 5,000 requests per day.
-Mokkari automatically enforces these limits locally to prevent unnecessary API
-calls. When a rate limit is exceeded, a `RateLimitError` is raised.
+The API has a fixed limit of 20 requests per minute, plus a daily limit that
+starts at 5,000 requests and is raised for
+[OpenCollective](https://opencollective.com/metron) donors (up to 25,000/day).
+Because the daily limit varies per user, mokkari doesn't hardcode it — it reads
+the `X-RateLimit-*` headers Metron returns with every response and pre-empts a
+request once those headers show a window is exhausted, avoiding an HTTP call
+that would fail anyway. When a rate limit is exceeded, a `RateLimitError` is
+raised.
+
+The most recently observed state is available via `session.rate_limit_status`:
+
+```python
+status = m.rate_limit_status
+print(f"Sustained remaining: {status.sustained.remaining}/{status.sustained.limit}")
+```
 
 ### Handling Rate Limits
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default [
     ignores: [
       "*~",
       "**/__pycache__",
+      ".claude",
       ".git",
       "!.circleci",
       ".mypy_cache",

--- a/mokkari/__init__.py
+++ b/mokkari/__init__.py
@@ -3,24 +3,19 @@
 __all__ = ["__version__", "api"]
 
 from importlib.metadata import version
-from typing import TYPE_CHECKING
 
 # Keep this at beginning of file to prevent circular import with session
 __version__ = version("mokkari")
 
 from mokkari import exceptions, session, sqlite_cache
 
-if TYPE_CHECKING:
-    from pyrate_limiter import AbstractBucket
 
-
-def api(  # noqa: PLR0913
+def api(
     username: str | None = None,
     passwd: str | None = None,
     cache: sqlite_cache.SqliteCache | None = None,
     user_agent: str | None = None,
     dev_mode: bool = False,
-    bucket: "AbstractBucket | None" = None,
 ) -> session.Session:
     """Entry function the sets login credentials for metron.cloud.
 
@@ -31,10 +26,6 @@ def api(  # noqa: PLR0913
         user_agent: The user agent string for the application using Mokkari.
             For example 'Foo Bar/1.0'.
         dev_mode: Whether the library should be run against a local Metron instance.
-        bucket: Optional pyrate_limiter bucket for rate limiting. If not provided,
-            a default SQLite-backed bucket is created and shared across sessions.
-            Pass a custom bucket to share rate limit state across workers
-            (e.g., using a Redis or database-backed bucket).
 
     Returns:
         A Session object.
@@ -43,27 +34,10 @@ def api(  # noqa: PLR0913
         AuthenticationError: If Metron returns with an invalid API credentials response.
 
     Examples:
-        Default SQLite-backed rate limiting (shared across sessions in the same process):
-
         >>> m = api("username", "password")
-
-        Redis-backed rate limiting (shared across multiple workers or processes):
-
-        >>> from pyrate_limiter import RedisBucket
-        >>> import redis
-        >>> pool = redis.ConnectionPool.from_url("redis://localhost:6379")
-        >>> bucket = RedisBucket.init(mokkari.session.DEFAULT_RATES, redis.Redis(connection_pool=pool), "mokkari")
-        >>> m = api("username", "password", bucket=bucket)
-
-        In-memory bucket (useful for testing or single-process use without a database):
-
-        >>> from pyrate_limiter import InMemoryBucket
-        >>> m = api("username", "password", bucket=InMemoryBucket(mokkari.session.DEFAULT_RATES))
 
     """
     if username is None or passwd is None:
         raise exceptions.AuthenticationError
 
-    return session.Session(
-        username, passwd, cache=cache, user_agent=user_agent, dev_mode=dev_mode, bucket=bucket
-    )
+    return session.Session(username, passwd, cache=cache, user_agent=user_agent, dev_mode=dev_mode)

--- a/mokkari/exceptions.py
+++ b/mokkari/exceptions.py
@@ -22,14 +22,19 @@ class ApiError(Exception):
 class RateLimitError(Exception):
     """Exception raised when API rate limits are exceeded.
 
-    This exception is raised when either the per-minute (30 requests) or per-day
-    (10,000 requests) rate limit is exceeded. The exception message includes:
+    This exception is raised when either the fixed per-minute burst limit (20
+    requests) or the per-day sustained limit is exceeded. The sustained limit
+    varies per user — it's 5,000/day by default, higher for OpenCollective
+    donors — so mokkari doesn't know it in advance; it's read from the
+    ``X-RateLimit-*`` headers Metron returns with each response. The exception
+    message includes:
     - Which rate limit was exceeded (minute or day)
-    - The specific limit value
+    - The specific limit value, as last reported by Metron
     - Human-readable wait time before the next request can be made
 
-    The rate limiting is enforced locally before making API requests, preventing
-    unnecessary HTTP calls that would fail on the server side.
+    Session pre-empts requests locally once the most recently observed
+    headers show a window is exhausted, avoiding an HTTP call that would fail
+    on the server side anyway.
 
     Attributes:
         retry_after: Number of seconds to wait before the next request can be made.
@@ -49,7 +54,7 @@ class RateLimitError(Exception):
         ...     issue = session.issue(1)
         ... except RateLimitError as e:
         ...     # Error message format:
-        ...     # "Rate limit exceeded: You have reached the 30 requests per minute limit.
+        ...     # "Rate limit exceeded: You have reached the 20 requests per minute limit.
         ...     #  Please wait 1 minute, 30 seconds before making another request."
         ...     print(f"Rate limited: {e}")
         ...     # Access the numeric delay value for programmatic retry

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -13,18 +13,16 @@ import platform
 import threading
 import time
 from collections import OrderedDict
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from email.utils import format_datetime as format_http_datetime
 from http import HTTPStatus
 from pathlib import Path
-from tempfile import gettempdir
-from typing import Any, Final, TypeVar, cast
+from typing import Any, Final, TypeVar
 from urllib.parse import urlencode
 
 import requests
-from platformdirs import user_cache_dir
 from pydantic import TypeAdapter, ValidationError
-from pyrate_limiter import AbstractBucket, Duration, Limiter, Rate, RateItem, SQLiteBucket
 
 from mokkari import __version__, exceptions, sqlite_cache
 from mokkari.schemas.arc import Arc, ArcPost
@@ -70,54 +68,54 @@ from mokkari.schemas.wish_list import (
 LOGGER = logging.getLogger(__name__)
 
 # Constants
-METRON_MINUTE_RATE_LIMIT: Final[int] = 20
-METRON_DAY_RATE_LIMIT: Final[int] = 5_000
 REQUEST_TIMEOUT: Final[int] = 20
 SECONDS_PER_HOUR: Final[int] = 3_600
 SECONDS_PER_MINUTE: Final[int] = 60
 METRON_URL = "https://metron.cloud/api/{}/"
 LOCAL_URL = "http://127.0.0.1:8000/api/{}/"
 
-DEFAULT_RATES: Final[list[Rate]] = [
-    Rate(METRON_MINUTE_RATE_LIMIT, Duration.MINUTE),
-    Rate(METRON_DAY_RATE_LIMIT, Duration.DAY),
-]
+# Metron reports rate-limit state via these response headers rather than a
+# fixed quota: the "sustained" (daily) limit varies per user based on
+# OpenCollective donor tier, so it can only be known by reading the headers
+# Metron sends back, not by hardcoding a value locally.
+HEADER_BURST_LIMIT: Final[str] = "X-RateLimit-Burst-Limit"
+HEADER_BURST_REMAINING: Final[str] = "X-RateLimit-Burst-Remaining"
+HEADER_BURST_RESET: Final[str] = "X-RateLimit-Burst-Reset"
+HEADER_SUSTAINED_LIMIT: Final[str] = "X-RateLimit-Sustained-Limit"
+HEADER_SUSTAINED_REMAINING: Final[str] = "X-RateLimit-Sustained-Remaining"
+HEADER_SUSTAINED_RESET: Final[str] = "X-RateLimit-Sustained-Reset"
 
-_default_bucket_instance: SQLiteBucket | None = None
-_default_bucket_lock = threading.Lock()
 
+@dataclass(frozen=True)
+class RateLimitWindow:
+    """A single rate-limit window (e.g. burst or sustained) as last reported by Metron.
 
-def _default_bucket_db_path() -> str:
-    """Return a stable, per-user path for the default rate-limit bucket.
-
-    Every process that shares this path shares the same request budget,
-    which is the point: a fresh timestamped temp file (pyrate_limiter's
-    own fallback) would give each process its own private 20/minute
-    allowance, letting the combined traffic from multiple processes blow
-    past Metron's actual server-side limit. platformdirs resolves to
-    $XDG_CACHE_HOME on Linux and the equivalent per-OS cache dir on macOS
-    and Windows.
+    Attributes:
+        limit: The maximum number of requests allowed in this window.
+        remaining: The number of requests left in the current window.
+        reset: When the window resets, as a UTC datetime.
     """
-    cache_dir = Path(user_cache_dir("mokkari"))
-    try:
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        return str(cache_dir / "rate_limit.sqlite")
-    except OSError:
-        # Cache dir isn't writable (read-only home, restricted container, etc.)
-        # Fall back to a fixed name in the temp dir rather than pyrate_limiter's
-        # own timestamped default, so same-host processes still share a budget.
-        return str(Path(gettempdir()) / "mokkari_rate_limit.sqlite")
+
+    limit: int | None = None
+    remaining: int | None = None
+    reset: datetime | None = None
 
 
-def _default_bucket() -> SQLiteBucket:
-    global _default_bucket_instance  # noqa: PLW0603
-    if _default_bucket_instance is None:
-        with _default_bucket_lock:
-            if _default_bucket_instance is None:
-                _default_bucket_instance = SQLiteBucket.init_from_file(
-                    DEFAULT_RATES, db_path=_default_bucket_db_path()
-                )
-    return _default_bucket_instance
+@dataclass(frozen=True)
+class RateLimitStatus:
+    """The most recently observed rate-limit state for a Session.
+
+    Populated from the ``X-RateLimit-*`` headers Metron sends with every
+    response. All fields are ``None`` until the first request completes.
+
+    Attributes:
+        burst: The short-term (per-minute) window, fixed for all users.
+        sustained: The daily window, whose limit varies by OpenCollective
+            donor tier.
+    """
+
+    burst: RateLimitWindow = field(default_factory=RateLimitWindow)
+    sustained: RateLimitWindow = field(default_factory=RateLimitWindow)
 
 
 class ResourceEndpoint:
@@ -189,10 +187,16 @@ class Session:
     creators, characters, publishers, series, issues, teams, arcs, and more. It handles
     authentication, rate limiting, caching, and response validation automatically.
 
-    The class implements automatic rate limiting to respect API quotas:
+    Metron enforces two rate-limit windows:
 
-    - 20 requests per minute
-    - 5,000 requests per day
+    - A fixed burst limit of 20 requests per minute for every user.
+    - A sustained daily limit that starts at 5,000 requests, and is raised for
+      OpenCollective donors (up to 25,000/day for the highest tier). Because
+      this limit varies per user and can change at any time, Session does not
+      track it locally with a fixed quota. Instead it reads the
+      ``X-RateLimit-*`` headers Metron returns with every response and only
+      pre-empts a request once those headers show the current window is
+      exhausted (see ``rate_limit_status``).
 
     **Important**: When rate limits are exceeded, a RateLimitError is raised immediately
     without making the API request. Applications must catch and handle this exception
@@ -201,7 +205,7 @@ class Session:
     Features:
 
     - Automatic authentication with username/password
-    - Built-in rate limiting with clear error messages
+    - Rate limiting driven by Metron's response headers, with clear error messages
     - Optional SQLite caching for improved performance
     - Comprehensive error handling and validation
     - Support for both read and write operations (write operations require admin permissions)
@@ -222,6 +226,8 @@ class Session:
         header (dict): HTTP headers sent with each request, including User-Agent.
         api_url (str): The base URL for API requests (production or development).
         cache (SqliteCache | None): The cache instance if provided.
+        rate_limit_status (RateLimitStatus): The most recently observed rate-limit
+            state, parsed from Metron's response headers.
 
     Examples:
         Basic usage:
@@ -276,18 +282,11 @@ class Session:
         ...                 raise
         >>> issue = fetch_with_rate_limit_handling(1)
 
-        Redis-backed rate limiting (shared across multiple workers or processes):
-
-        >>> from pyrate_limiter import RedisBucket
-        >>> import redis
-        >>> pool = redis.ConnectionPool.from_url("redis://localhost:6379")
-        >>> bucket = RedisBucket.init(DEFAULT_RATES, redis.Redis(connection_pool=pool), "mokkari")
-        >>> session = Session("username", "password", bucket=bucket)
-
-        In-memory bucket (useful for testing or single-process use without a database):
-
-        >>> from pyrate_limiter import InMemoryBucket
-        >>> session = Session("username", "password", bucket=InMemoryBucket(DEFAULT_RATES))
+        Inspecting the current rate-limit state:
+        >>> session = Session("username", "password")
+        >>> issue = session.issue(1)
+        >>> status = session.rate_limit_status
+        >>> print(f"Sustained remaining: {status.sustained.remaining}/{status.sustained.limit}")
 
     Raises:
         ApiError: For general API errors, authentication failures, or network issues.
@@ -311,14 +310,13 @@ class Session:
         UniversePost,
     )
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         username: str,
         passwd: str,
         cache: sqlite_cache.SqliteCache | None = None,
         user_agent: str | None = None,
         dev_mode: bool = False,
-        bucket: AbstractBucket | None = None,
     ) -> None:
         """Initialize a Session object with authentication and configuration.
 
@@ -332,10 +330,6 @@ class Session:
             cache: Optional SqliteCache instance for response caching.
             user_agent: Optional custom user agent string to prepend to the default.
             dev_mode: If True, use local development server instead of production.
-            bucket: Optional pyrate_limiter bucket for rate limiting. If not provided,
-                a default SQLite-backed bucket is created and shared across sessions.
-                Pass a custom bucket to share rate limit state across workers
-                (e.g., using a Redis or database-backed bucket).
         """
         self.username = username
         self.passwd = passwd
@@ -345,8 +339,19 @@ class Session:
         }
         self.api_url = LOCAL_URL if dev_mode else METRON_URL
         self.cache = cache
-        self._bucket = bucket or _default_bucket()
-        self._limiter = Limiter(self._bucket)
+        self._rate_limit_lock = threading.Lock()
+        self._rate_limit_status = RateLimitStatus()
+
+    @property
+    def rate_limit_status(self) -> RateLimitStatus:
+        """Return the most recently observed rate-limit state.
+
+        Populated from the ``X-RateLimit-*`` headers Metron sends with every
+        response. Fields are ``None`` until the first request completes, or if
+        Metron did not report that window.
+        """
+        with self._rate_limit_lock:
+            return self._rate_limit_status
 
     def _get(
         self,
@@ -2000,7 +2005,7 @@ class Session:
             ApiError: For connection errors or timeouts.
         """
         try:
-            return requests.request(
+            response = requests.request(
                 method,
                 url,
                 params=params,
@@ -2016,6 +2021,9 @@ class Session:
         ) as err:
             msg = f"Connection error: {err!r}"
             raise exceptions.ApiError(msg) from err
+
+        self._update_rate_limit_status(response.headers)
+        return response
 
     def _handle_http_response(self, response: requests.Response) -> dict[str, Any]:
         """Handle HTTP response, parsing JSON and checking for errors.
@@ -2053,32 +2061,86 @@ class Session:
 
         return resp
 
+    @staticmethod
+    def _parse_rate_limit_window(
+        headers: Any, limit_header: str, remaining_header: str, reset_header: str
+    ) -> RateLimitWindow | None:
+        """Parse one rate-limit window (burst or sustained) out of response headers.
+
+        Returns ``None`` when none of the three headers for this window are present,
+        so a response missing rate-limit headers entirely doesn't clobber
+        previously observed state.
+        """
+        limit = headers.get(limit_header)
+        remaining = headers.get(remaining_header)
+        reset = headers.get(reset_header)
+        if limit is None and remaining is None and reset is None:
+            return None
+        return RateLimitWindow(
+            limit=int(limit) if limit is not None else None,
+            remaining=int(remaining) if remaining is not None else None,
+            reset=datetime.fromtimestamp(int(reset), tz=timezone.utc)
+            if reset is not None
+            else None,
+        )
+
+    def _update_rate_limit_status(self, headers: Any) -> None:
+        """Update the session's rate-limit state from a response's headers."""
+        burst = self._parse_rate_limit_window(
+            headers, HEADER_BURST_LIMIT, HEADER_BURST_REMAINING, HEADER_BURST_RESET
+        )
+        sustained = self._parse_rate_limit_window(
+            headers, HEADER_SUSTAINED_LIMIT, HEADER_SUSTAINED_REMAINING, HEADER_SUSTAINED_RESET
+        )
+        if burst is None and sustained is None:
+            return
+        with self._rate_limit_lock:
+            self._rate_limit_status = RateLimitStatus(
+                burst=burst or self._rate_limit_status.burst,
+                sustained=sustained or self._rate_limit_status.sustained,
+            )
+
+    @staticmethod
+    def _seconds_until_window_resets(window: RateLimitWindow, now: datetime) -> float:
+        """Seconds until ``window`` allows another request, or 0 if it already does."""
+        if window.remaining is None or window.remaining > 0 or window.reset is None:
+            return 0.0
+        return max(0.0, (window.reset - now).total_seconds())
+
     def _check_rate_limit(self) -> None:
         """Check rate limits before making a request.
 
+        Metron's sustained (daily) limit varies per user based on OpenCollective
+        donor tier, so mokkari doesn't track it locally with a fixed quota.
+        Instead it trusts the most recently observed ``X-RateLimit-*`` response
+        headers, and only pre-empts a request once those headers show a window
+        is already exhausted.
+
         Raises:
-            RateLimitError: When the API rate limit is exceeded.
+            RateLimitError: When the last known rate-limit headers show the
+                burst or sustained window is exhausted and hasn't reset yet.
         """
-        acquired = self._limiter.try_acquire("metron", 1, blocking=False)
-        if not acquired:
-            item = RateItem("metron", cast("int", self._bucket.now()), weight=1)
-            delay_ms = cast("int", self._bucket.waiting(item))
-            delay = delay_ms / 1000 if delay_ms > 0 else 0
+        status = self.rate_limit_status
+        now = datetime.now(timezone.utc)
+        burst_wait = self._seconds_until_window_resets(status.burst, now)
+        sustained_wait = self._seconds_until_window_resets(status.sustained, now)
 
-            failing_rate = self._bucket.failing_rate
-            if failing_rate is not None and failing_rate.interval >= Duration.DAY.value:
-                limit_type = "day"
-                limit_value = METRON_DAY_RATE_LIMIT
-            else:
-                limit_type = "minute"
-                limit_value = METRON_MINUTE_RATE_LIMIT
+        delay = max(burst_wait, sustained_wait)
+        if delay <= 0:
+            return
 
-            msg = (
-                f"Rate limit exceeded: You have reached the {limit_value:,} requests per {limit_type} limit. "
-                f"Please wait {format_time(delay)} before making another request."
-            )
-            LOGGER.warning(msg)
-            raise exceptions.RateLimitError(msg, retry_after=delay)
+        if sustained_wait >= burst_wait:
+            limit_type, limit_value = "day", status.sustained.limit
+        else:
+            limit_type, limit_value = "minute", status.burst.limit
+        limit_str = f"{limit_value:,}" if limit_value is not None else "your"
+
+        msg = (
+            f"Rate limit exceeded: You have reached the {limit_str} requests per {limit_type} limit. "
+            f"Please wait {format_time(delay)} before making another request."
+        )
+        LOGGER.warning(msg)
+        raise exceptions.RateLimitError(msg, retry_after=delay)
 
     def _request_data(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
 ]
-dependencies = [
-  "requests>=2.26.0",
-  "pydantic>=2.10.3",
-  "pyrate-limiter>=4",
-  "platformdirs>=4",
-]
+dependencies = ["requests>=2.26.0", "pydantic>=2.10.3"]
 
 [project.urls]
 Homepage = "https://github.com/Metron-Project/mokkari"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,9 @@ This module contains pytest fixtures.
 import os
 
 import pytest
-from pyrate_limiter import Duration, InMemoryBucket, Rate
 
 from mokkari import api
 from mokkari.session import Session
-
-_HIGH_RATE = [Rate(10_000, Duration.MINUTE)]
 
 
 @pytest.fixture(scope="session")
@@ -32,5 +29,4 @@ def talker(dummy_username: str, dummy_password: str) -> Session:
     return api(
         username=dummy_username,
         passwd=dummy_password,
-        bucket=InMemoryBucket(_HIGH_RATE),
     )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import HttpUrl, ValidationError
-from pyrate_limiter import Duration, Rate
 from requests.exceptions import ConnectionError as ConnError, HTTPError
 
 import mokkari.session as session_module
@@ -1918,6 +1917,7 @@ def test__request_data_get(monkeypatch, session):
         def __init__(self, status_code=200):
             self._json = {"foo": "bar"}
             self.status_code = status_code
+            self.headers = {}
 
         def raise_for_status(self):
             pass
@@ -1938,6 +1938,7 @@ def test__request_data_post_list(monkeypatch, session):
         def __init__(self, status_code=201):
             self._json = {"foo": "bar"}
             self.status_code = status_code
+            self.headers = {}
 
         def raise_for_status(self):
             pass
@@ -1959,6 +1960,7 @@ def test__request_data_post_with_image(monkeypatch, session, tmp_path):
         def __init__(self, status_code=201):
             self._json = {"foo": "bar"}
             self.status_code = status_code
+            self.headers = {}
 
         def raise_for_status(self):
             pass
@@ -1993,6 +1995,7 @@ def test__request_data_detail(monkeypatch, session):
         def __init__(self, status_code=200):
             self._json = {"foo": "bar"}
             self.status_code = status_code
+            self.headers = {}
 
         def raise_for_status(self):
             if self.status_code >= 400:
@@ -2102,59 +2105,124 @@ def test__prepare_request_payload_image_model_no_image_file(session: Session) ->
 # ============================================================================
 # Rate Limiting Tests
 # ============================================================================
+#
+# Metron's sustained (daily) limit is dynamic per user (higher for
+# OpenCollective donors), so Session tracks rate limits reactively from the
+# X-RateLimit-* response headers instead of a fixed local quota.
 
 
-def _make_mock_bucket(rate: Rate, delay_ms: int) -> MagicMock:
-    """Create a mock bucket that simulates a rate limit being exceeded."""
-    mock_bucket = MagicMock()
-    mock_bucket.now.return_value = 1_000_000
-    mock_bucket.waiting.return_value = delay_ms
-    mock_bucket.failing_rate = rate
-    return mock_bucket
+def test_format_time_minutes_and_seconds() -> None:
+    """format_time formats a sub-hour delay as minutes and seconds."""
+    assert session_module.format_time(90.5) == "1 minute, 30 seconds"
 
 
-def test_rate_limit_minute_exceeded(session: Session) -> None:
-    """Test that minute rate limit raises RateLimitError with correct message."""
-    # Arrange: simulate minute rate limit (60 seconds = 60,000 ms)
-    mock_bucket = _make_mock_bucket(Rate(20, Duration.MINUTE), delay_ms=60_000)
-    session._bucket = mock_bucket
-
-    with patch.object(session._limiter, "try_acquire", return_value=False):
-        # Act & Assert
-        with pytest.raises(exceptions.RateLimitError) as excinfo:
-            session._request_data("GET", "https://test.com/api/issue/1")
-
-        error_msg = str(excinfo.value)
-        assert "Rate limit exceeded" in error_msg
-        assert "20 requests per minute" in error_msg
-        assert "Please wait" in error_msg
-        assert "1 minute" in error_msg
-        assert excinfo.value.retry_after == 60.0
+def test_format_time_hours() -> None:
+    """format_time formats a multi-hour delay correctly."""
+    assert session_module.format_time(9_000) == "2 hours, 30 minutes"
 
 
-def test_rate_limit_day_exceeded(session: Session) -> None:
-    """Test that daily rate limit raises RateLimitError with correct message."""
-    # Arrange: simulate daily rate limit (86400 seconds = 86,400,000 ms)
-    mock_bucket = _make_mock_bucket(Rate(5_000, Duration.DAY), delay_ms=86_400_000)
-    session._bucket = mock_bucket
-
-    with patch.object(session._limiter, "try_acquire", return_value=False):
-        # Act & Assert
-        with pytest.raises(exceptions.RateLimitError) as excinfo:
-            session._request_data("GET", "https://test.com/api/issue/1")
-
-        error_msg = str(excinfo.value)
-        assert "Rate limit exceeded" in error_msg
-        assert "5,000 requests per day" in error_msg
-        assert "Please wait" in error_msg
-        assert "24 hours" in error_msg
-        assert excinfo.value.retry_after == 86400.0
+def test_rate_limit_status_defaults_to_unknown(session: Session) -> None:
+    """A fresh session has no observed rate-limit state until a request completes."""
+    status = session.rate_limit_status
+    assert status.burst == session_module.RateLimitWindow()
+    assert status.sustained == session_module.RateLimitWindow()
 
 
-def test_rate_limit_blocks_request(session: Session, monkeypatch) -> None:
-    """Test that rate limit prevents HTTP request from being made."""
-    # Arrange
-    mock_bucket = _make_mock_bucket(Rate(20, Duration.MINUTE), delay_ms=60_000)
+def test_update_rate_limit_status_parses_headers(session: Session) -> None:
+    """Headers from a response are parsed into the session's rate-limit status."""
+    headers = {
+        "X-RateLimit-Burst-Limit": "20",
+        "X-RateLimit-Burst-Remaining": "19",
+        "X-RateLimit-Burst-Reset": "1700000060",
+        "X-RateLimit-Sustained-Limit": "10000",
+        "X-RateLimit-Sustained-Remaining": "9999",
+        "X-RateLimit-Sustained-Reset": "1700086400",
+    }
+
+    session._update_rate_limit_status(headers)
+
+    status = session.rate_limit_status
+    assert status.burst.limit == 20
+    assert status.burst.remaining == 19
+    assert status.burst.reset == datetime.datetime.fromtimestamp(
+        1700000060, tz=datetime.timezone.utc
+    )
+    assert status.sustained.limit == 10_000
+    assert status.sustained.remaining == 9_999
+    assert status.sustained.reset == datetime.datetime.fromtimestamp(
+        1700086400, tz=datetime.timezone.utc
+    )
+
+
+def test_update_rate_limit_status_ignores_response_without_headers(session: Session) -> None:
+    """A response missing rate-limit headers shouldn't erase previously observed state."""
+    session._update_rate_limit_status({"X-RateLimit-Burst-Limit": "20"})
+
+    session._update_rate_limit_status({})
+
+    assert session.rate_limit_status.burst.limit == 20
+
+
+def test_check_rate_limit_allows_request_when_no_state_observed(session: Session) -> None:
+    """Nothing is known yet, so the first request is never pre-emptively blocked."""
+    session._check_rate_limit()  # should not raise
+
+
+def test_check_rate_limit_allows_request_when_remaining_positive(session: Session) -> None:
+    """Test that a window with remaining quota does not block."""
+    reset = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=30)
+    session._rate_limit_status = session_module.RateLimitStatus(
+        burst=session_module.RateLimitWindow(limit=20, remaining=5, reset=reset)
+    )
+
+    session._check_rate_limit()  # should not raise
+
+
+def test_check_rate_limit_raises_when_burst_exhausted(session: Session) -> None:
+    """Test that an exhausted burst (minute) window raises RateLimitError."""
+    reset = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
+    session._rate_limit_status = session_module.RateLimitStatus(
+        burst=session_module.RateLimitWindow(limit=20, remaining=0, reset=reset)
+    )
+
+    with pytest.raises(exceptions.RateLimitError) as excinfo:
+        session._check_rate_limit()
+
+    error_msg = str(excinfo.value)
+    assert "Rate limit exceeded" in error_msg
+    assert "20 requests per minute" in error_msg
+    assert "Please wait" in error_msg
+    assert excinfo.value.retry_after == pytest.approx(60, abs=2)
+
+
+def test_check_rate_limit_raises_when_sustained_exhausted(session: Session) -> None:
+    """Test that an exhausted sustained (daily) window raises RateLimitError.
+
+    The sustained limit here (10,000) reflects an elevated OpenCollective donor
+    tier rather than the default 5,000/day, since it's read straight from
+    whatever the server last reported.
+    """
+    reset = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+    session._rate_limit_status = session_module.RateLimitStatus(
+        sustained=session_module.RateLimitWindow(limit=10_000, remaining=0, reset=reset)
+    )
+
+    with pytest.raises(exceptions.RateLimitError) as excinfo:
+        session._check_rate_limit()
+
+    error_msg = str(excinfo.value)
+    assert "Rate limit exceeded" in error_msg
+    assert "10,000 requests per day" in error_msg
+    assert "Please wait" in error_msg
+    assert excinfo.value.retry_after == pytest.approx(86_400, abs=2)
+
+
+def test_check_rate_limit_blocks_request(session: Session, monkeypatch) -> None:
+    """Test that an exhausted window prevents the HTTP request from being made."""
+    reset = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
+    session._rate_limit_status = session_module.RateLimitStatus(
+        burst=session_module.RateLimitWindow(limit=20, remaining=0, reset=reset)
+    )
 
     mock_request_called = {"called": False}
 
@@ -2163,57 +2231,21 @@ def test_rate_limit_blocks_request(session: Session, monkeypatch) -> None:
         return MagicMock()
 
     monkeypatch.setattr("mokkari.session.requests.request", mock_request)
-    session._bucket = mock_bucket
 
-    with patch.object(session._limiter, "try_acquire", return_value=False):
-        # Act & Assert
-        with pytest.raises(exceptions.RateLimitError):
-            session._request_data("GET", "https://test.com/api/issue/1")
+    with pytest.raises(exceptions.RateLimitError):
+        session._request_data("GET", "https://test.com/api/issue/1")
 
-        assert not mock_request_called["called"], (
-            "HTTP request should not be made when rate limited"
-        )
-
-
-def test_rate_limit_bucket_full(session: Session) -> None:
-    """Test handling of a bucket-full minute rate limit with a 90.5-second delay."""
-    # Arrange: 90,500 ms = 1 minute, 30 seconds
-    mock_bucket = _make_mock_bucket(Rate(20, Duration.MINUTE), delay_ms=90_500)
-    session._bucket = mock_bucket
-
-    with patch.object(session._limiter, "try_acquire", return_value=False):
-        # Act & Assert
-        with pytest.raises(exceptions.RateLimitError) as excinfo:
-            session._request_data("GET", "https://test.com/api/issue/1")
-
-        error_msg = str(excinfo.value)
-        assert "Rate limit exceeded" in error_msg
-        assert "20 requests per minute" in error_msg
-        assert "1 minute, 30 seconds" in error_msg
-
-
-def test_rate_limit_format_time_hours(session: Session) -> None:
-    """Test that rate limit error message correctly formats hours."""
-    # Arrange: 2.5 hours = 9,000 seconds = 9,000,000 ms
-    mock_bucket = _make_mock_bucket(Rate(5_000, Duration.DAY), delay_ms=9_000_000)
-    session._bucket = mock_bucket
-
-    with patch.object(session._limiter, "try_acquire", return_value=False):
-        # Act & Assert
-        with pytest.raises(exceptions.RateLimitError) as excinfo:
-            session._request_data("GET", "https://test.com/api/issue/1")
-
-        error_msg = str(excinfo.value)
-        assert "2 hours, 30 minutes" in error_msg
+    assert not mock_request_called["called"], "HTTP request should not be made when rate limited"
 
 
 def test_rate_limit_allows_successful_request(session: Session, monkeypatch) -> None:
-    """Test that requests proceed normally when rate limit is not exceeded."""
+    """Test that requests proceed normally when no rate limit is exhausted."""
 
     # Arrange
     class DummyResp:
         def __init__(self):
             self.status_code = 200
+            self.headers = {}
 
         def raise_for_status(self):
             pass
@@ -2223,13 +2255,43 @@ def test_rate_limit_allows_successful_request(session: Session, monkeypatch) -> 
 
     monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
 
-    # Mock limiter to allow request (no exception)
-    with patch.object(session._limiter, "try_acquire", return_value=True):
-        # Act
-        result = session._request_data("GET", "https://test.com/api/issue/1")
+    # Act
+    result = session._request_data("GET", "https://test.com/api/issue/1")
 
-        # Assert
-        assert result == {"id": 1, "name": "Test"}
+    # Assert
+    assert result == {"id": 1, "name": "Test"}
+
+
+def test_request_data_updates_rate_limit_status_from_response(
+    session: Session, monkeypatch
+) -> None:
+    """A successful response's headers should update the session's rate-limit status."""
+
+    class DummyResp:
+        def __init__(self):
+            self.status_code = 200
+            self.headers = {
+                "X-RateLimit-Burst-Limit": "20",
+                "X-RateLimit-Burst-Remaining": "18",
+                "X-RateLimit-Burst-Reset": "1700000060",
+                "X-RateLimit-Sustained-Limit": "5000",
+                "X-RateLimit-Sustained-Remaining": "4998",
+                "X-RateLimit-Sustained-Reset": "1700086400",
+            }
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": 1, "name": "Test"}
+
+    monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
+
+    result = session._request_data("GET", "https://test.com/api/issue/1")
+
+    assert result == {"id": 1, "name": "Test"}
+    assert session.rate_limit_status.burst.remaining == 18
+    assert session.rate_limit_status.sustained.remaining == 4998
 
 
 # ============================================================================
@@ -2251,11 +2313,10 @@ def test_if_modified_since_returns_none_on_304(session: Session, monkeypatch) ->
 
     monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
 
-    with patch.object(session._limiter, "try_acquire", return_value=True):
-        # Act
-        result = session.arc(
-            1, if_modified_since=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
-        )
+    # Act
+    result = session.arc(
+        1, if_modified_since=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    )
 
     # Assert
     assert result is None
@@ -2278,17 +2339,14 @@ def test_if_modified_since_returns_resource_on_200(session: Session, monkeypatch
 
     monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
 
-    with (
-        patch.object(session._limiter, "try_acquire", return_value=True),
-        patch(
-            "mokkari.session.TypeAdapter.validate_python",
-            return_value=Arc(
-                id=1,
-                name="Updated Arc",
-                desc="",
-                resource_url=HttpUrl("https://foo.bar"),
-                modified=datetime.datetime.now(),
-            ),
+    with patch(
+        "mokkari.session.TypeAdapter.validate_python",
+        return_value=Arc(
+            id=1,
+            name="Updated Arc",
+            desc="",
+            resource_url=HttpUrl("https://foo.bar"),
+            modified=datetime.datetime.now(),
         ),
     ):
         # Act
@@ -2320,12 +2378,11 @@ def test_if_modified_since_sends_header(session: Session, monkeypatch) -> None:
 
     monkeypatch.setattr("mokkari.session.requests.request", mock_request)
 
-    with patch.object(session._limiter, "try_acquire", return_value=True):
-        # Act
-        session.arc(
-            1,
-            if_modified_since=datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
-        )
+    # Act
+    session.arc(
+        1,
+        if_modified_since=datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+    )
 
     # Assert — verify the header was formatted as RFC 7231
     assert captured_kwargs["headers"]["If-Modified-Since"] == "Wed, 01 Jan 2025 12:00:00 GMT"
@@ -2350,9 +2407,8 @@ def test_if_modified_since_naive_datetime_treated_as_utc(session: Session, monke
 
     monkeypatch.setattr("mokkari.session.requests.request", mock_request)
 
-    with patch.object(session._limiter, "try_acquire", return_value=True):
-        # Act — pass a naive datetime
-        session.arc(1, if_modified_since=datetime.datetime(2025, 6, 15, 8, 30, 0))  # noqa: DTZ001
+    # Act — pass a naive datetime
+    session.arc(1, if_modified_since=datetime.datetime(2025, 6, 15, 8, 30, 0))  # noqa: DTZ001
 
     # Assert — should be formatted as UTC
     assert captured_kwargs["headers"]["If-Modified-Since"] == "Sun, 15 Jun 2025 08:30:00 GMT"
@@ -2382,9 +2438,8 @@ def test_if_modified_since_non_utc_timezone_converted(session: Session, monkeypa
     # 2025-01-01 06:00:00 CST == 2025-01-01 12:00:00 UTC
     dt_cst = datetime.datetime(2025, 1, 1, 6, 0, 0, tzinfo=cst)
 
-    with patch.object(session._limiter, "try_acquire", return_value=True):
-        # Act
-        session.arc(1, if_modified_since=dt_cst)
+    # Act
+    session.arc(1, if_modified_since=dt_cst)
 
     # Assert — should be converted to UTC
     assert captured_kwargs["headers"]["If-Modified-Since"] == "Wed, 01 Jan 2025 12:00:00 GMT"
@@ -2411,17 +2466,14 @@ def test_if_modified_since_bypasses_cache(session: Session, dummy_cache, monkeyp
 
     monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
 
-    with (
-        patch.object(session._limiter, "try_acquire", return_value=True),
-        patch(
-            "mokkari.session.TypeAdapter.validate_python",
-            return_value=Arc(
-                id=1,
-                name="Fresh",
-                desc="",
-                resource_url=HttpUrl("https://foo.bar"),
-                modified=datetime.datetime.now(),
-            ),
+    with patch(
+        "mokkari.session.TypeAdapter.validate_python",
+        return_value=Arc(
+            id=1,
+            name="Fresh",
+            desc="",
+            resource_url=HttpUrl("https://foo.bar"),
+            modified=datetime.datetime.now(),
         ),
     ):
         # Act — with if_modified_since, cache should be ignored
@@ -2457,70 +2509,6 @@ def test_without_if_modified_since_uses_cache(session: Session, dummy_cache) -> 
     # Assert
     assert isinstance(result, Arc)
     assert result.name == "Cached Arc"
-
-
-def test_custom_bucket_is_used() -> None:
-    """Test that a custom bucket passed to Session is used instead of the default."""
-    # Arrange
-    custom_bucket = MagicMock()
-
-    with patch("mokkari.session.Limiter"):
-        session = Session(username="user", passwd="pass", bucket=custom_bucket)  # noqa: S106
-
-    # The custom bucket should be set on the session
-    assert session._bucket is custom_bucket
-
-
-def test_default_bucket_shared_across_sessions() -> None:
-    """Test that sessions without a custom bucket share the lazily-created default."""
-    # Reset the singleton so test is not order-dependent
-    original = session_module._default_bucket_instance
-    session_module._default_bucket_instance = None
-    try:
-        s1 = Session(username="user", passwd="pass")  # noqa: S106
-        s2 = Session(username="user", passwd="pass")  # noqa: S106
-        assert s1._bucket is s2._bucket
-    finally:
-        session_module._default_bucket_instance = original
-
-
-def test_default_bucket_db_path_uses_platform_cache_dir(tmp_path: Path) -> None:
-    """Test that the default bucket path lives under the platform cache dir.
-
-    A timestamped temp file (pyrate_limiter's own default) would give each
-    process its own private budget instead of one shared across processes.
-    """
-    with patch("mokkari.session.user_cache_dir", return_value=str(tmp_path / "mokkari")):
-        path = session_module._default_bucket_db_path()
-
-    assert path == str(tmp_path / "mokkari" / "rate_limit.sqlite")
-    assert (tmp_path / "mokkari").is_dir()
-
-
-def test_default_bucket_db_path_is_stable_across_calls(tmp_path: Path) -> None:
-    """Repeated calls must resolve to the same file so unrelated processes agree."""
-    with patch("mokkari.session.user_cache_dir", return_value=str(tmp_path / "mokkari")):
-        first = session_module._default_bucket_db_path()
-        second = session_module._default_bucket_db_path()
-
-    assert first == second
-
-
-def test_default_bucket_db_path_falls_back_when_cache_dir_unwritable(tmp_path: Path) -> None:
-    """Test the fallback when the platform cache dir can't be created.
-
-    It should use a fixed temp path rather than pyrate_limiter's own
-    timestamped default.
-    """
-    unwritable = tmp_path / "cache"
-    with (
-        patch("mokkari.session.user_cache_dir", return_value=str(unwritable)),
-        patch.object(Path, "mkdir", side_effect=OSError("read-only filesystem")),
-    ):
-        path = session_module._default_bucket_db_path()
-
-    assert path.endswith("mokkari_rate_limit.sqlite")
-    assert "pyrate_limiter_" not in path
 
 
 def test_wish_list(session: Session) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -648,9 +648,7 @@ name = "mokkari"
 version = "3.29.1"
 source = { editable = "." }
 dependencies = [
-    { name = "platformdirs" },
     { name = "pydantic" },
-    { name = "pyrate-limiter" },
     { name = "requests" },
 ]
 
@@ -683,9 +681,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "platformdirs", specifier = ">=4" },
     { name = "pydantic", specifier = ">=2.10.3" },
-    { name = "pyrate-limiter", specifier = ">=4" },
     { name = "requests", specifier = ">=2.26.0" },
 ]
 
@@ -950,15 +946,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d7/29e1e5e882f79133631f7bcace42d23db493f616463c157a1ab614bf69dd/pyproject_api-1.10.1-py3-none-any.whl", hash = "sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a", size = 12992, upload-time = "2026-05-28T14:22:12.711Z" },
-]
-
-[[package]]
-name = "pyrate-limiter"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/27/e564f33ea085c63d5540f707b31aeb50a4992eac2da655dc02435a760a07/pyrate_limiter-4.4.0.tar.gz", hash = "sha256:2c0c720c4fa16c5d8199e4821bf34507fb49c007a25b786cec6fb94ffd0844aa", size = 90955, upload-time = "2026-06-14T10:52:03.021Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl", hash = "sha256:f738dfa3c7ac1222a5ea3d31e00cfd31b5592b13ade4077afe9e8ac6293381f5", size = 43102, upload-time = "2026-06-14T10:52:01.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Metron's daily rate limit is no longer fixed — it now varies per user based on OpenCollective donor tier (5,000/day default, up to 25,000/day for the highest tier). A hardcoded local `pyrate_limiter` bucket can't represent a limit that changes per credential, so local enforcement was falling out of sync with what the server actually allows.

## What changed

- `Session` no longer enforces rate limits with a local `pyrate_limiter` bucket/SQLite file. Instead it reads the `X-RateLimit-Burst-*` and `X-RateLimit-Sustained-*` headers Metron returns on every response, and only pre-empts a request once those headers show a window is already exhausted — avoiding an HTTP call that would fail server-side anyway.
- New `RateLimitWindow` / `RateLimitStatus` dataclasses and a `Session.rate_limit_status` property expose the most recently observed limit/remaining/reset state for both the burst (per-minute) and sustained (daily) windows.
- Removed the `bucket` constructor/`api()` parameter and the `pyrate_limiter`/`platformdirs` dependencies, since there's no longer a local bucket to inject or a cache directory to manage.
- Updated `RateLimitError` docs, README, and tests for the new behavior.

## Notes

Since limits are only known after at least one response, `Session` can't pre-empt the very first request even if the account is already over quota — it will hit the API and get a 429/RateLimitError back from Metron on that first call, same as before this change for a cold local bucket.
