### PR TITLE
Make SqliteCache safe to share across threads

### DIFF
--- a/mokkari/sqlite_cache.py
+++ b/mokkari/sqlite_cache.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 
 class SqliteCache:
     """A class for caching data using SQLite.
+
+    Safe to share across threads: all database access goes through a single
+    connection guarded by an internal lock, since sqlite3 connections aren't
+    safe for concurrent use from multiple threads on their own.
 
     Methods:
         - __init__: Initializes a new SqliteCache.
@@ -31,9 +36,10 @@ class SqliteCache:
     ) -> None:
         """Initialize a new SqliteCache."""
         self.expire = expire
-        self.con = sqlite3.connect(db_name)
-        self.cur = self.con.cursor()
-        self.cur.execute("CREATE TABLE IF NOT EXISTS responses (key, json, expire)")
+        self._lock = threading.Lock()
+        self.con = sqlite3.connect(db_name, check_same_thread=False)
+        with self._lock:
+            self.con.execute("CREATE TABLE IF NOT EXISTS responses (key, json, expire)")
         self.cleanup()
 
     def get(self: SqliteCache, key: str) -> Any | None:
@@ -45,8 +51,9 @@ class SqliteCache:
         Returns:
             The retrieved data if found, or None if not found.
         """
-        self.cur.execute("SELECT json FROM responses WHERE key = ?", (key,))
-        return json.loads(result[0]) if (result := self.cur.fetchone()) else None
+        with self._lock:
+            result = self.con.execute("SELECT json FROM responses WHERE key = ?", (key,)).fetchone()
+        return json.loads(result[0]) if result else None
 
     def store(self: SqliteCache, key: str, value: str) -> None:
         """Save data to the cache database.
@@ -58,21 +65,23 @@ class SqliteCache:
         Returns:
             None
         """
-        self.cur.execute(
-            "INSERT INTO responses(key, json, expire) VALUES(?, ?, ?)",
-            (key, json.dumps(value), self._determine_expire_str()),
-        )
-        self.con.commit()
+        with self._lock:
+            self.con.execute(
+                "INSERT INTO responses(key, json, expire) VALUES(?, ?, ?)",
+                (key, json.dumps(value), self._determine_expire_str()),
+            )
+            self.con.commit()
 
     def cleanup(self: SqliteCache) -> None:
         """Remove any expired data from the cache database."""
         if not self.expire:
             return
-        self.cur.execute(
-            "DELETE FROM responses WHERE expire < ?;",
-            (datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),),
-        )
-        self.con.commit()
+        with self._lock:
+            self.con.execute(
+                "DELETE FROM responses WHERE expire < ?;",
+                (datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),),
+            )
+            self.con.commit()
 
     def _determine_expire_str(self: SqliteCache) -> str:
         """Determine the expiration date string for cache data."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,10 +5,12 @@ This module contains tests for SqliteCache objects.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 import requests_mock
 
-from mokkari import api, exceptions
+from mokkari import api, exceptions, sqlite_cache
 
 
 class NoGet:
@@ -48,6 +50,19 @@ def test_no_store(dummy_username: str, dummy_password: str) -> None:
 
         with pytest.raises(exceptions.CacheError):
             m.series(5)
+
+
+def test_thread_safety() -> None:
+    """Concurrent get/store calls from multiple threads should not raise."""
+    cache = sqlite_cache.SqliteCache(":memory:")
+
+    def worker(i: int) -> None:
+        key = f"key-{i}"
+        cache.store(key, {"id": i})
+        assert cache.get(key) == {"id": i}
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(worker, range(100)))
 
 
 # def test_sql_store(dummy_username: str, dummy_password: str) -> None:


### PR DESCRIPTION
## Summary
- `SqliteCache` previously reused a single `sqlite3` cursor created in `__init__` for every `get`/`store`/`cleanup` call, and opened its connection with the default `check_same_thread=True` — calling the cache from any thread other than the one that constructed it raised `sqlite3.ProgrammingError` immediately, so a `Session` with a cache couldn't be used from a thread pool at all.
- Open the connection with `check_same_thread=False`, drop the shared cursor in favor of per-call cursors, and guard all database access with an internal lock so concurrent callers serialize safely instead of crashing or corrupting cursor state.
