### PR TITLE
Add previous/next reading order links to ReadingListRead

### DIFF
--- a/docs/mokkari/schemas/reading_list.md
+++ b/docs/mokkari/schemas/reading_list.md
@@ -3,4 +3,5 @@
 :::mokkari.schemas.reading_list.ReadingListIssue
 :::mokkari.schemas.reading_list.ReadingListItem
 :::mokkari.schemas.reading_list.ReadingListList
+:::mokkari.schemas.reading_list.ReadingListNav
 :::mokkari.schemas.reading_list.ReadingListRead

--- a/docs/mokkari/session.md
+++ b/docs/mokkari/session.md
@@ -1,4 +1,5 @@
-:::mokkari.session.Session
 :::mokkari.session.RateLimitStatus
 :::mokkari.session.RateLimitWindow
 :::mokkari.session.format_time
+:::mokkari.session.Session
+

--- a/mokkari/schemas/reading_list.py
+++ b/mokkari/schemas/reading_list.py
@@ -6,6 +6,7 @@ This module provides the following classes:
 - ReadingListIssue
 - ReadingListItem
 - ReadingListList
+- ReadingListNav
 - ReadingListRead
 """
 
@@ -15,6 +16,7 @@ __all__ = [
     "ReadingListIssue",
     "ReadingListItem",
     "ReadingListList",
+    "ReadingListNav",
     "ReadingListRead",
 ]
 
@@ -159,6 +161,18 @@ class ReadingListList(BaseModel):
         return v
 
 
+class ReadingListNav(BaseModel):
+    """A data model representing a minimal reading list reference for previous/next links.
+
+    Attributes:
+        id (int): The unique identifier of the reading list.
+        name (str): The name of the reading list.
+    """
+
+    id: int
+    name: str
+
+
 class ReadingListRead(BaseModel):
     """A data model representing a reading list in detailed view.
 
@@ -174,6 +188,8 @@ class ReadingListRead(BaseModel):
         attribution_source (str): Source where this reading list information was obtained.
         attribution_url (HttpUrl, optional): URL of the specific page where this reading
             list was obtained.
+        previous (ReadingListNav, optional): The previous reading list in the reading order.
+        next (ReadingListNav, optional): The next reading list in the reading order.
         average_rating (float): The average rating of the reading list.
         rating_count (int): The number of ratings for the reading list.
         items_url (str): URL to the paginated items endpoint.
@@ -191,6 +207,8 @@ class ReadingListRead(BaseModel):
     is_private: bool = False
     attribution_source: str
     attribution_url: HttpUrl | None = Field(default=None, max_length=200)
+    previous: ReadingListNav | None = None
+    next: ReadingListNav | None = None
     average_rating: float | None = None
     rating_count: int
     items_url: str

--- a/tests/test_reading_list_schemas.py
+++ b/tests/test_reading_list_schemas.py
@@ -10,6 +10,7 @@ from mokkari.schemas.reading_list import (
     ReadingListIssue,
     ReadingListItem,
     ReadingListList,
+    ReadingListNav,
     ReadingListRead,
     User,
 )
@@ -271,9 +272,27 @@ def test_reading_list_read_creation(reading_list_read_data):
     assert reading_list.is_private is False
     assert reading_list.attribution_source == "CBRO"
     assert str(reading_list.attribution_url) == "https://example.com/reading-list"
+    assert reading_list.previous is None
+    assert reading_list.next is None
     assert reading_list.items_url == "https://api.example.com/reading_list/1/items/"
     assert reading_list.resource_url == "https://api.example.com/reading_list/1/"
     assert isinstance(reading_list.modified, datetime)
+
+
+def test_reading_list_read_with_previous_and_next(reading_list_read_data):
+    """Test creating a ReadingListRead with previous and next reading order links."""
+    data = {
+        **reading_list_read_data,
+        "previous": {"id": 2, "name": "Batgirl: Mother"},
+        "next": {"id": 3, "name": "Batgirl: The Book of Shiva"},
+    }
+    reading_list = ReadingListRead(**data)
+    assert isinstance(reading_list.previous, ReadingListNav)
+    assert reading_list.previous.id == 2
+    assert reading_list.previous.name == "Batgirl: Mother"
+    assert isinstance(reading_list.next, ReadingListNav)
+    assert reading_list.next.id == 3
+    assert reading_list.next.name == "Batgirl: The Book of Shiva"
 
 
 def test_reading_list_read_creation_minimal(user_data):


### PR DESCRIPTION
## Summary
- Adds a `ReadingListNav` model and wires `previous`/`next` reading-order links into `ReadingListRead`, matching Metron's new API schema (PR #566)
- Updates schema docs to include `ReadingListNav`
- Reorders `session.md` doc entries so `Session` is listed after the rate-limit helpers
