### PR TITLE
Add average_rating and rating_count fields to Issue schema

### DIFF
--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -198,6 +198,8 @@ class Issue(CommonIssue):
         universes (list[BaseResource], optional): The universes related to the issue.
         reprints (list[Reprint], optional): The reprints of the issue.
         variants (list[Variant], optional): The variants of the issue.
+        average_rating (Decimal, optional): The average community rating (1-5) of the issue.
+        rating_count (int): The number of community ratings submitted for the issue.
         cv_id (int, optional): The Comic Vine ID of the issue.
         gcd_id (int, optional): The Grand Comics Database ID of the issue.
         resource_url (HttpUrl): The URL of the issue resource.
@@ -224,6 +226,8 @@ class Issue(CommonIssue):
     universes: list[BaseResource] = []
     reprints: list[Reprint] = []
     variants: list[Variant] = []
+    average_rating: Decimal | None = None
+    rating_count: int
     cv_id: int | None = None
     gcd_id: int | None = None
     resource_url: HttpUrl

--- a/tests/test_issue_schemas.py
+++ b/tests/test_issue_schemas.py
@@ -351,6 +351,8 @@ def test_issue_creation_full_data():
         "universes": [{"id": 1, "name": "DC Universe", "modified": now}],
         "reprints": [],
         "variants": [],
+        "average_rating": 4.25,
+        "rating_count": 8,
         "cv_id": 123456,
         "gcd_id": 654321,
         "resource_url": "https://example.com/issue/1",
@@ -366,6 +368,8 @@ def test_issue_creation_full_data():
     assert issue.price == Decimal("3.99")
     assert issue.rating.name == "T+"
     assert issue.page_count == 32
+    assert issue.average_rating == 4.25
+    assert issue.rating_count == 8
     assert issue.cv_id == 123456
     assert issue.gcd_id == 654321
 
@@ -396,6 +400,7 @@ def test_issue_creation_minimal_data():
         "desc": "",
         "price": None,
         "price_currency": "",
+        "rating_count": 0,
         "resource_url": "https://example.com/issue/1",
     }
     issue = Issue(**data)
@@ -407,6 +412,8 @@ def test_issue_creation_minimal_data():
     assert issue.characters == []
     assert issue.teams == []
     assert issue.universes == []
+    assert issue.average_rating is None
+    assert issue.rating_count == 0
     assert issue.reprints == []
     assert issue.variants == []
     assert issue.cv_id is None
@@ -440,6 +447,7 @@ def test_issue_field_aliases():
         "desc": "",
         "price": None,
         "price_currency": "",
+        "rating_count": 0,
         "resource_url": "https://example.com/issue/1",
     }
     issue = Issue(**data)
@@ -596,6 +604,7 @@ def test_empty_string_handling():
         "desc": "",
         "price": None,
         "price_currency": "",
+        "rating_count": 0,
         "resource_url": "https://example.com/issue/1",
     }
     issue = Issue(**data)
@@ -635,6 +644,7 @@ def test_list_field_types():
         "desc": "",
         "price": None,
         "price_currency": "",
+        "rating_count": 0,
         "resource_url": "https://example.com/issue/1",
     }
     issue = Issue(**data)
@@ -729,6 +739,7 @@ def test_optional_nested_objects():
         "desc": "",
         "price": None,
         "price_currency": "",
+        "rating_count": 0,
         "resource_url": "https://example.com/issue/1",
     }
     issue = Issue(**data)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -27,6 +27,7 @@ _BASE_ISSUE = {
     "desc": "",
     "price": None,
     "price_currency": "",
+    "rating_count": 0,
     "modified": _MODIFIED,
 }
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -950,6 +950,7 @@ def test_issue(session: Session) -> None:
                 isbn="",
                 upc="",
                 desc="",
+                rating_count=0,
             ),
         ),
     ):


### PR DESCRIPTION
## Summary
- Metron PR #558 adds a 5-star community rating system for issues (separate from the existing personal collection rating).
- The issue detail endpoint now returns `average_rating` (a quantized `Decimal`, `null` until the issue has ratings) and `rating_count` — both read-only aggregates, and only present on the detail endpoint (not the list endpoint).
- Adds `average_rating: Decimal | None` and `rating_count: int` to the `Issue` schema to match.
