### PR TITLE
Add alt_names field to Series and IssueSeries schemas

### DIFF
--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -121,6 +121,7 @@ class IssueSeries(BaseModel):
         id (int): The unique identifier of the issue series.
         name (str): The name of the issue series.
         sort_name (str): The name used for sorting the issue series.
+        alt_names (list[str], optional): Alternative names for the issue series.
         volume (int): The volume number of the issue series.
         year_began (int): The year the issue's series began.
         series_type (GenericItem): The type of the issue series.
@@ -131,6 +132,7 @@ class IssueSeries(BaseModel):
     id: int
     name: str
     sort_name: str
+    alt_names: list[str] = []
     volume: int
     year_began: int
     series_type: GenericItem

--- a/mokkari/schemas/series.py
+++ b/mokkari/schemas/series.py
@@ -77,6 +77,7 @@ class Series(CommonSeries):
     Attributes:
         name (str): The name of the series.
         sort_name (str): The name used for sorting the series.
+        alt_names (list[str], optional): Alternative names for the series.
         series_type (GenericItem): The type of the series.
         status (str): The status of the series.
         publisher (GenericItem): The publisher of the series.
@@ -92,6 +93,7 @@ class Series(CommonSeries):
 
     name: str
     sort_name: str
+    alt_names: list[str] = []
     series_type: GenericItem
     status: str
     publisher: GenericItem
@@ -111,6 +113,7 @@ class SeriesPost(BaseModel):
     Attributes:
         name (str, optional): The name of the series.
         sort_name (str, optional): The name used for sorting the series.
+        alt_names (list[str], optional): Alternative names for the series.
         volume (int, optional): The volume number of the series.
         series_type (int, optional): The ID of the series type.
         status (int, optional): The ID of the series status.
@@ -127,6 +130,7 @@ class SeriesPost(BaseModel):
 
     name: str | None = None
     sort_name: str | None = None
+    alt_names: list[str] | None = None
     volume: int | None = None
     series_type: int | None = None
     status: int | None = None
@@ -148,6 +152,7 @@ class SeriesPostResponse(BaseResource, SeriesPost):
         id (int): The unique identifier of the series.
         name (str, optional): The name of the series.
         sort_name (str, optional): The name used for sorting the series.
+        alt_names (list[str], optional): Alternative names for the series.
         volume (int, optional): The volume number of the series.
         series_type (int, optional): The ID of the series type.
         status (int, optional): The ID of the series status.

--- a/tests/test_issue_schemas.py
+++ b/tests/test_issue_schemas.py
@@ -41,6 +41,7 @@ def issue_series_data():
         "id": 1,
         "name": "Batman",
         "sort_name": "Batman",
+        "alt_names": ["Bat-Man"],
         "volume": 1,
         "year_began": 1940,
         "series_type": {"id": 1, "name": "Ongoing Series"},
@@ -205,6 +206,7 @@ def test_issue_series_creation(issue_series_data):
     assert series.id == 1
     assert series.name == "Batman"
     assert series.sort_name == "Batman"
+    assert series.alt_names == ["Bat-Man"]
     assert series.volume == 1
     assert series.year_began == 1940
     assert series.series_type.name == "Ongoing Series"
@@ -224,6 +226,20 @@ def test_issue_series_creation_without_genres():
     }
     series = IssueSeries(**data)
     assert series.genres == []
+
+
+def test_issue_series_creation_without_alt_names():
+    """Test that alt_names defaults to an empty list when absent."""
+    data = {
+        "id": 1,
+        "name": "Batman",
+        "sort_name": "Batman",
+        "volume": 1,
+        "year_began": 1940,
+        "series_type": {"id": 1, "name": "Ongoing Series"},
+    }
+    series = IssueSeries(**data)
+    assert series.alt_names == []
 
 
 def test_issue_series_validation_missing_series_type():

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -288,6 +288,27 @@ def test_series_list_with_year_end() -> None:
     assert series.year_end == 2018
 
 
+def test_series_with_alt_names() -> None:
+    """Test series with alternative names."""
+    series = Series(
+        **{
+            **_FULL_SERIES,
+            "id": 3315,
+            "name": "The Sandman",
+            "sort_name": "Sandman",
+            "alt_names": ["Sandman: The Dreaming"],
+            "resource_url": "https://metron.cloud/series/sandman-1989/",
+        }
+    )
+    assert series.alt_names == ["Sandman: The Dreaming"]
+
+
+def test_series_without_alt_names() -> None:
+    """Test that alt_names defaults to an empty list when absent."""
+    death = Series(**_FULL_SERIES)
+    assert death.alt_names == []
+
+
 def test_series_list_without_year_end() -> None:
     """Test that year_end is None when absent from a series list entry."""
     series = BaseSeries(


### PR DESCRIPTION
## Summary
- Add `alt_names` field to the `Series`, `SeriesPost`, and `SeriesPostResponse` schemas to support alternative names for a series (e.g. "Sandman: The Dreaming" for "The Sandman").
- Add `alt_names` to the nested `IssueSeries` schema (the `series` object embedded in the issue detail response), matching the same field on the standalone `Series` schema.
- Both fields default to an empty list when absent from the API response.
