### PR TITLE
Add support for token-based API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ A python wrapper for the [Metron Comic Book Database](https://metron.cloud) API.
 pip install mokkari
 ```
 
+## Authentication
+
+Mokkari supports two authentication methods:
+
+```python
+import mokkari
+
+# Token authentication (generate a token from your metron.cloud account page)
+m = mokkari.api(api_token="your-api-token")
+
+# Username/password (Basic Auth)
+m = mokkari.api(username, password)
+```
+
 ## Example Usage
 
 ```python

--- a/mokkari/__init__.py
+++ b/mokkari/__init__.py
@@ -7,15 +7,16 @@ from importlib.metadata import version
 # Keep this at beginning of file to prevent circular import with session
 __version__ = version("mokkari")
 
-from mokkari import exceptions, session, sqlite_cache
+from mokkari import session, sqlite_cache
 
 
-def api(
+def api(  # noqa: PLR0913, PLR0917
     username: str | None = None,
     passwd: str | None = None,
     cache: sqlite_cache.SqliteCache | None = None,
     user_agent: str | None = None,
     dev_mode: bool = False,
+    api_token: str | None = None,
 ) -> session.Session:
     """Entry function the sets login credentials for metron.cloud.
 
@@ -26,18 +27,26 @@ def api(
         user_agent: The user agent string for the application using Mokkari.
             For example 'Foo Bar/1.0'.
         dev_mode: Whether the library should be run against a local Metron instance.
+        api_token: An API token used for Bearer-token authentication. Takes
+            precedence over username/passwd when both are provided.
 
     Returns:
         A Session object.
 
     Raises:
-        AuthenticationError: If Metron returns with an invalid API credentials response.
+        AuthenticationError: If neither an api_token nor a complete username/passwd
+            pair is provided.
 
     Examples:
         >>> m = api("username", "password")
+        >>> m = api(api_token="your-token-here")
 
     """
-    if username is None or passwd is None:
-        raise exceptions.AuthenticationError
-
-    return session.Session(username, passwd, cache=cache, user_agent=user_agent, dev_mode=dev_mode)
+    return session.Session(
+        username=username,
+        passwd=passwd,
+        cache=cache,
+        user_agent=user_agent,
+        dev_mode=dev_mode,
+        api_token=api_token,
+    )

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -216,7 +216,7 @@ class Session:
 
     Features:
 
-    - Automatic authentication with username/password
+    - Automatic authentication with username/password or a Bearer API token
     - Rate limiting driven by Metron's response headers, with clear error messages
     - Optional SQLite caching for improved performance
     - Comprehensive error handling and validation
@@ -231,10 +231,13 @@ class Session:
         cache: Optional SqliteCache instance for caching responses to improve performance.
         user_agent: Optional custom user agent string to append to the default user agent.
         dev_mode: If True, connects to local development instance at 127.0.0.1:8000 instead of production.
+        api_token: API token for Bearer-token authentication. Takes precedence
+            over username/passwd when both are provided.
 
     Attributes:
-        username (str): The username used for API authentication.
-        passwd (str): The password used for API authentication.
+        username (str | None): The username used for API authentication.
+        passwd (str | None): The password used for API authentication.
+        api_token (str | None): The API token used for Bearer-token authentication, if provided.
         header (dict): HTTP headers sent with each request, including User-Agent.
         api_url (str): The base URL for API requests (production or development).
         cache (SqliteCache | None): The cache instance if provided.
@@ -246,6 +249,9 @@ class Session:
         >>> session = Session("username", "password")
         >>> issue = session.issue(1)
         >>> print(issue)
+
+        Token authentication:
+        >>> session = Session(api_token="your-api-token")
 
         With caching:
         >>> from mokkari.sqlite_cache import SqliteCache
@@ -301,6 +307,8 @@ class Session:
         >>> print(f"Sustained remaining: {status.sustained.remaining}/{status.sustained.limit}")
 
     Raises:
+        AuthenticationError: If neither an api_token nor a complete username/passwd
+            pair is provided.
         ApiError: For general API errors, authentication failures, or network issues.
         RateLimitError: When API rate limits are exceeded (both local tracking and server-side).
         CacheError: For cache-related errors.
@@ -322,13 +330,14 @@ class Session:
         UniversePost,
     )
 
-    def __init__(
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
-        username: str,
-        passwd: str,
+        username: str | None = None,
+        passwd: str | None = None,
         cache: sqlite_cache.SqliteCache | None = None,
         user_agent: str | None = None,
         dev_mode: bool = False,
+        api_token: str | None = None,
     ) -> None:
         """Initialize a Session object with authentication and configuration.
 
@@ -342,13 +351,29 @@ class Session:
             cache: Optional SqliteCache instance for response caching.
             user_agent: Optional custom user agent string to prepend to the default.
             dev_mode: If True, use local development server instead of production.
+            api_token: API token for Bearer-token authentication. Takes precedence
+                over username/passwd when both are provided.
+
+        Raises:
+            AuthenticationError: If neither api_token nor a complete username/passwd
+                pair is provided.
         """
+        has_basic_auth = username is not None and passwd is not None
+        if api_token is None and not has_basic_auth:
+            raise exceptions.AuthenticationError
+
         self.username = username
         self.passwd = passwd
+        self.api_token = api_token
         self.header = {
             "User-Agent": f"{f'{user_agent} ' if user_agent is not None else ''}"
             f"Mokkari/{__version__} ({platform.system()}; {platform.release()})"
         }
+        if api_token is not None:
+            self.header["Authorization"] = f"Bearer {api_token}"
+            self._auth = None
+        else:
+            self._auth = (username, passwd)
         self.api_url = LOCAL_URL if dev_mode else METRON_URL
         self.cache = cache
         self._rate_limit_lock = threading.Lock()
@@ -2022,7 +2047,7 @@ class Session:
                 url,
                 params=params,
                 timeout=REQUEST_TIMEOUT,
-                auth=(self.username, self.passwd),
+                auth=self._auth,
                 headers=header,
                 data=data_dict,
                 files=files,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,3 +27,11 @@ def test_api() -> None:
         print(f"mokkari.api() raised {exc} unexpectedly!")
 
     assert m.__class__.__name__ == session.Session.__name__
+
+    m = None
+    try:
+        m = api(api_token="Something")
+    except Exception as exc:  # noqa: BLE001
+        print(f"mokkari.api() raised {exc} unexpectedly!")
+
+    assert m.__class__.__name__ == session.Session.__name__

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S106
 """Test Session module.
 
 This module contains tests for Session objects.
@@ -72,7 +73,7 @@ from mokkari.session import Session
 def session() -> Session:
     # Arrange
     # Provide a Session with dummy credentials and no cache
-    return Session(username="user", passwd="pass", cache=None, user_agent="pytest", dev_mode=False)  # noqa: S106
+    return Session(username="user", passwd="pass", cache=None, user_agent="pytest", dev_mode=False)
 
 
 @pytest.fixture
@@ -90,6 +91,69 @@ def dummy_cache():
             self._store[key] = value
 
     return DummyCache()
+
+
+def test_session_init_raises_without_any_credentials() -> None:
+    """Test that Session() raises AuthenticationError with no credentials."""
+    with pytest.raises(exceptions.AuthenticationError):
+        Session()
+
+
+def test_session_init_raises_with_partial_basic_auth_and_no_token() -> None:
+    """Test that partial username/passwd without a token raises AuthenticationError."""
+    with pytest.raises(exceptions.AuthenticationError):
+        Session(username="user")
+
+    with pytest.raises(exceptions.AuthenticationError):
+        Session(passwd="pass")
+
+
+def test_session_init_basic_auth_sets_auth_tuple() -> None:
+    """Test that username/passwd authentication sets a Basic Auth tuple."""
+    s = Session(username="user", passwd="pass")
+
+    assert s._auth == ("user", "pass")
+    assert "Authorization" not in s.header
+
+
+def test_session_init_token_sets_bearer_header() -> None:
+    """Test that api_token authentication sets a Bearer Authorization header."""
+    s = Session(api_token="abc123")
+
+    assert s.header["Authorization"] == "Bearer abc123"
+    assert s._auth is None
+
+
+def test_session_init_token_takes_precedence_over_basic_auth() -> None:
+    """Test that api_token takes precedence when username/passwd are also given."""
+    s = Session(username="user", passwd="pass", api_token="abc123")
+
+    assert s.header["Authorization"] == "Bearer abc123"
+    assert s._auth is None
+
+
+def test_execute_http_request_uses_basic_auth(session: Session, monkeypatch) -> None:
+    """Test that _execute_http_request sends a Basic Auth tuple for username/passwd sessions."""
+    mock_request = MagicMock(return_value=MagicMock(headers={}))
+    monkeypatch.setattr("mokkari.session.requests.request", mock_request)
+
+    session._execute_http_request("GET", "https://test.com/api/issue/1", {}, {}, None, None)
+
+    assert mock_request.call_args.kwargs["auth"] == ("user", "pass")
+
+
+def test_execute_http_request_uses_bearer_header(monkeypatch) -> None:
+    """Test that _execute_http_request sends no auth tuple for token sessions."""
+    token_session = Session(api_token="abc123")
+    mock_request = MagicMock(return_value=MagicMock(headers={}))
+    monkeypatch.setattr("mokkari.session.requests.request", mock_request)
+
+    token_session._execute_http_request(
+        "GET", "https://test.com/api/issue/1", {}, token_session.header, None, None
+    )
+
+    assert mock_request.call_args.kwargs["auth"] is None
+    assert mock_request.call_args.kwargs["headers"]["Authorization"] == "Bearer abc123"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Metron now accepts an `Authorization: Bearer <token>` header as an alternative to HTTP Basic Auth (see https://metron-project.github.io/blog/token-authentication); this is additive, Basic Auth keeps working unchanged for now.
- Add an `api_token` parameter to `mokkari.api()` and `Session` — when provided, it takes precedence over `username`/`passwd`, and the `Authorization: Bearer <token>` header is set once at construction instead of computed per-request.
- `username`/`passwd` are now optional on `Session`/`api()` since a token-only session is valid; credential validation (`AuthenticationError` when neither a token nor a full username/passwd pair is given) moved from `api()` into `Session.__init__` so direct `Session(...)` construction is validated too.
- `api_token` is appended as the last parameter on both signatures (not inserted in the middle) so existing positional call sites remain unaffected.
- Document the new auth method in the README and add test coverage for both auth modes, precedence when both are given, and the missing/partial-credentials error cases.

Closes #153
