### PR TITLE
Add collection_add and collection_delete methods

### DIFF
--- a/docs/mokkari/schemas/collection.md
+++ b/docs/mokkari/schemas/collection.md
@@ -1,4 +1,5 @@
 :::mokkari.schemas.collection.BookFormat
+:::mokkari.schemas.collection.CollectionAddItem
 :::mokkari.schemas.collection.CollectionFormatStat
 :::mokkari.schemas.collection.CollectionIssue
 :::mokkari.schemas.collection.CollectionList

--- a/mokkari/schemas/collection.py
+++ b/mokkari/schemas/collection.py
@@ -10,6 +10,7 @@ This module provides the following classes:
 - CollectionIssue
 - CollectionList
 - CollectionRead
+- CollectionAddItem
 - MissingIssue
 - MissingSeries
 - CollectionFormatStat
@@ -22,6 +23,7 @@ This module provides the following classes:
 
 __all__ = [
     "BookFormat",
+    "CollectionAddItem",
     "CollectionFormatStat",
     "CollectionIssue",
     "CollectionList",
@@ -273,6 +275,36 @@ class CollectionRead(BaseModel):
     resource_url: str
     created_on: datetime
     modified: datetime
+
+
+class CollectionAddItem(BaseModel):
+    """A data model representing a request to add an issue to the collection.
+
+    Attributes:
+        issue_id (int): The unique identifier of the issue to add.
+        quantity (int): Number of copies owned (default 1).
+        book_format (str): Format of the comic (print, digital, or both). Defaults to PRINT.
+        grade (Decimal, optional): Comic book grade (CGC scale).
+        grading_company (str): Professional grading company.
+        purchase_date (date, optional): Date when the issue was purchased.
+        purchase_price (Decimal, optional): Price paid for this issue.
+        purchase_price_currency (str): Currency for purchase_price (default "USD").
+        purchase_store (str): Store or vendor where purchased.
+        storage_location (str): Physical location where the issue is stored.
+        notes (str): Additional notes about this collection item.
+    """
+
+    issue_id: int
+    quantity: int = Field(default=1, ge=1)
+    book_format: str = BookFormat.PRINT.value
+    grade: Decimal | None = None
+    grading_company: str = ""
+    purchase_date: date | None = None
+    purchase_price: Decimal | None = None
+    purchase_price_currency: str = "USD"
+    purchase_store: str = ""
+    storage_location: str = ""
+    notes: str = ""
 
 
 class MissingIssue(BaseModel):

--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -29,6 +29,7 @@ from mokkari.schemas.arc import Arc, ArcPost
 from mokkari.schemas.base import BaseResource
 from mokkari.schemas.character import Character, CharacterPost, CharacterPostResponse
 from mokkari.schemas.collection import (
+    CollectionAddItem,
     CollectionList,
     CollectionRead,
     CollectionStats,
@@ -1659,6 +1660,51 @@ class Session:
         return self._patch_resource(
             ResourceEndpoint.COLLECTION, _id, data, CollectionUpdateResponse
         )
+
+    def collection_add(self, data: CollectionAddItem) -> CollectionRead:
+        """Add an issue to the authenticated user's collection.
+
+        Note: This endpoint requires authentication.
+
+        Args:
+            data: CollectionAddItem object containing the issue_id and optional
+                  quantity, grade, and purchase details.
+
+        Returns:
+            CollectionRead: The created (or updated, if the issue was already
+                             in the collection) collection item.
+
+        Raises:
+            ApiError: If the issue is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> from mokkari.schemas.collection import CollectionAddItem
+            >>> item = session.collection_add(CollectionAddItem(issue_id=1, quantity=2))
+            >>> print(f"Added: {item.issue.series.name} #{item.issue.number}")
+        """
+        return self._handle_write_request(
+            "POST", [ResourceEndpoint.COLLECTION, "add"], data, CollectionRead
+        )
+
+    def collection_delete(self, _id: int) -> None:
+        """Remove an item from the authenticated user's collection.
+
+        Note: Users can only remove items from their own collection.
+
+        Args:
+            _id: The unique identifier for the collection item to remove.
+
+        Raises:
+            ApiError: If the collection item is not found or if there's an API error.
+            RateLimitError: If the Metron API rate limit has been exceeded.
+
+        Examples:
+            >>> session = Session("username", "password")
+            >>> session.collection_delete(1)
+        """
+        self._send_void("DELETE", [ResourceEndpoint.COLLECTION, _id])
 
     # Pull list methods
     def pull_list(self) -> PullListRead:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -20,6 +20,7 @@ from mokkari.schemas.arc import Arc, ArcPost
 from mokkari.schemas.base import BaseResource
 from mokkari.schemas.character import Character, CharacterPost, CharacterPostResponse
 from mokkari.schemas.collection import (
+    CollectionAddItem,
     CollectionFormatStat,
     CollectionIssue,
     CollectionList,
@@ -1919,6 +1920,79 @@ def test_collection_patch_api_error(session: Session) -> None:
         pytest.raises(exceptions.ApiError),
     ):
         session.collection_patch(1, data)
+
+
+def test_collection_add(session: Session) -> None:
+    # Arrange
+    add_request = CollectionAddItem(issue_id=1, quantity=2, purchase_price=Decimal("3.99"))
+    resp = {
+        "id": 100,
+        "user": {"id": 1, "username": "test"},
+        "issue": {
+            "id": 1,
+            "series": {"id": 1, "name": "Batman", "volume": 1, "year_began": 1940},
+            "number": "1",
+            "cover_date": "2024-01-01",
+            "modified": "2024-01-01T12:00:00Z",
+        },
+        "quantity": 2,
+        "book_format": "PRINT",
+        "grading_company": "",
+        "is_read": False,
+        "resource_url": "https://api.example.com/collection/100/",
+        "created_on": "2024-01-01T12:00:00Z",
+        "modified": "2024-01-01T12:00:00Z",
+    }
+    with (
+        patch.object(session, "_send", return_value=resp),
+        patch(
+            "mokkari.session.TypeAdapter.validate_python",
+            return_value=CollectionRead(
+                id=100,
+                user=User(id=1, username="test"),
+                issue=CollectionIssue(
+                    id=1,
+                    series=BasicSeries(id=1, name="Batman", volume=1, year_began=1940),
+                    number="1",
+                    cover_date=datetime.date(2024, 1, 1),
+                    modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                ),
+                quantity=2,
+                book_format="PRINT",
+                grading_company="",
+                is_read=False,
+                resource_url="https://api.example.com/collection/100/",
+                created_on=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+                modified=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            ),
+        ),
+    ):
+        # Act
+        result = session.collection_add(add_request)
+        # Assert
+        assert isinstance(result, CollectionRead)
+        assert result.id == 100
+        assert result.quantity == 2
+
+
+def test_collection_add_api_error(session: Session) -> None:
+    # Arrange
+    add_request = CollectionAddItem(issue_id=1)
+    with (
+        patch.object(session, "_send", side_effect=exceptions.ApiError("fail")),
+        pytest.raises(exceptions.ApiError),
+    ):
+        session.collection_add(add_request)
+
+
+def test_collection_delete(session: Session) -> None:
+    # Arrange
+    with patch.object(session, "_send_void") as mock_send_void:
+        # Act
+        result = session.collection_delete(1)
+        # Assert
+        assert result is None
+        mock_send_void.assert_called_once_with("DELETE", ["collection", 1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add `CollectionAddItem` schema and `Session.collection_add()` to support `POST /api/collection/add/`, letting callers add an issue to their collection with optional quantity, grade, and purchase details.
- Add `Session.collection_delete()` to support `DELETE /api/collection/{id}/`, letting callers remove an item from their collection.
- Document `CollectionAddItem` in the schema docs.
