### PR TITLE
Add Italian comics support to Publisher, Series, and Issue schemas

### DIFF
--- a/mokkari/schemas/issue.py
+++ b/mokkari/schemas/issue.py
@@ -62,11 +62,11 @@ class PricePost(BaseModel):
 
     Attributes:
         amount (Decimal): The price amount.
-        currency (str): The currency code (USD or GBP).
+        currency (str): The currency code (USD, GBP, EUR, or ITL).
     """
 
     amount: Decimal
-    currency: Literal["USD", "GBP"]
+    currency: Literal["USD", "GBP", "EUR", "ITL"]
 
 
 class CreditPost(BaseModel):
@@ -126,6 +126,7 @@ class IssueSeries(BaseModel):
         year_began (int): The year the issue's series began.
         series_type (GenericItem): The type of the issue series.
         genres (list[GenericItem], optional): The genres associated with the issue series.
+        language (str, optional): The ISO 639-1 language code of the issue series.
     """
 
     # TODO: Should this have the status field?
@@ -137,6 +138,7 @@ class IssueSeries(BaseModel):
     year_began: int
     series_type: GenericItem
     genres: list[GenericItem] = []
+    language: str = ""
 
 
 class CommonIssue(BaseModel):
@@ -248,7 +250,7 @@ class IssuePost(BaseModel):
         store_date (date, optional): The store date of the issue.
         foc_date (date, optional): The final order cutoff date of the issue.
         price (Decimal | PricePost, optional): The price of the issue. Pass a plain Decimal for
-            USD or a PricePost object for non-USD currencies (e.g. GBP).
+            USD or a PricePost object for non-USD currencies (e.g. GBP, EUR, ITL).
         rating (int, optional): The ID of the rating of the issue.
         sku (str, optional): The SKU of the issue.
         isbn (str, optional): The ISBN of the issue.

--- a/mokkari/schemas/publisher.py
+++ b/mokkari/schemas/publisher.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF012
 """Publisher module.
 
 This module provides the following classes:
@@ -32,6 +33,7 @@ class Publisher(BaseResource):
     """A data model representing a publisher that extends BaseResource.
 
     Attributes:
+        alt_names (list[str], optional): Alternative names for the publisher.
         founded (int, optional): The year the publisher was founded.
         country: str: An ISO 3166-1 2-letter country code.
         desc (str): The description of the publisher.
@@ -41,6 +43,7 @@ class Publisher(BaseResource):
         resource_url (HttpUrl): The URL of the publisher resource.
     """
 
+    alt_names: list[str] = []
     founded: int | None = None
     country: Annotated[str, ensure_country_code_length]
     desc: str
@@ -55,6 +58,7 @@ class PublisherPost(BaseModel):
 
     Attributes:
         name (str, optional): The name of the publisher.
+        alt_names (list[str], optional): Alternative names for the publisher.
         founded (int, optional): The year the publisher was founded.
         country: str: An ISO 3166-1 2-letter country code. Defaults to 'US'.
         desc (str, optional): The description of the publisher.
@@ -64,6 +68,7 @@ class PublisherPost(BaseModel):
     """
 
     name: str | None = None
+    alt_names: list[str] | None = None
     founded: int | None = None
     country: Annotated[str, ensure_country_code_length] = "US"
     desc: str | None = None

--- a/mokkari/schemas/series.py
+++ b/mokkari/schemas/series.py
@@ -78,6 +78,7 @@ class Series(CommonSeries):
         name (str): The name of the series.
         sort_name (str): The name used for sorting the series.
         alt_names (list[str], optional): Alternative names for the series.
+        language (str, optional): The ISO 639-1 language code of the series.
         series_type (GenericItem): The type of the series.
         status (str): The status of the series.
         publisher (GenericItem): The publisher of the series.
@@ -94,6 +95,7 @@ class Series(CommonSeries):
     name: str
     sort_name: str
     alt_names: list[str] = []
+    language: str = ""
     series_type: GenericItem
     status: str
     publisher: GenericItem
@@ -114,6 +116,7 @@ class SeriesPost(BaseModel):
         name (str, optional): The name of the series.
         sort_name (str, optional): The name used for sorting the series.
         alt_names (list[str], optional): Alternative names for the series.
+        language (str, optional): The ISO 639-1 language code of the series. Defaults to 'en'.
         volume (int, optional): The volume number of the series.
         series_type (int, optional): The ID of the series type.
         status (int, optional): The ID of the series status.
@@ -131,6 +134,7 @@ class SeriesPost(BaseModel):
     name: str | None = None
     sort_name: str | None = None
     alt_names: list[str] | None = None
+    language: str | None = None
     volume: int | None = None
     series_type: int | None = None
     status: int | None = None
@@ -153,6 +157,7 @@ class SeriesPostResponse(BaseResource, SeriesPost):
         name (str, optional): The name of the series.
         sort_name (str, optional): The name used for sorting the series.
         alt_names (list[str], optional): Alternative names for the series.
+        language (str, optional): The ISO 639-1 language code of the series. Defaults to 'en'.
         volume (int, optional): The volume number of the series.
         series_type (int, optional): The ID of the series type.
         status (int, optional): The ID of the series status.

--- a/tests/test_issue_schemas.py
+++ b/tests/test_issue_schemas.py
@@ -46,6 +46,7 @@ def issue_series_data():
         "year_began": 1940,
         "series_type": {"id": 1, "name": "Ongoing Series"},
         "genres": [{"id": 1, "name": "Superhero"}],
+        "language": "en",
     }
 
 
@@ -212,6 +213,7 @@ def test_issue_series_creation(issue_series_data):
     assert series.series_type.name == "Ongoing Series"
     assert len(series.genres) == 1
     assert series.genres[0].name == "Superhero"
+    assert series.language == "en"
 
 
 def test_issue_series_creation_without_genres():
@@ -240,6 +242,20 @@ def test_issue_series_creation_without_alt_names():
     }
     series = IssueSeries(**data)
     assert series.alt_names == []
+
+
+def test_issue_series_creation_without_language():
+    """Test that language defaults to an empty string when absent."""
+    data = {
+        "id": 1,
+        "name": "Batman",
+        "sort_name": "Batman",
+        "volume": 1,
+        "year_began": 1940,
+        "series_type": {"id": 1, "name": "Ongoing Series"},
+    }
+    series = IssueSeries(**data)
+    assert series.language == ""
 
 
 def test_issue_series_validation_missing_series_type():
@@ -683,10 +699,24 @@ def test_price_post_creation_gbp():
     assert price.currency == "GBP"
 
 
+def test_price_post_creation_eur():
+    """Test creating a PricePost with EUR currency."""
+    price = PricePost(amount=Decimal("3.99"), currency="EUR")
+    assert price.amount == Decimal("3.99")
+    assert price.currency == "EUR"
+
+
+def test_price_post_creation_itl():
+    """Test creating a PricePost with ITL currency."""
+    price = PricePost(amount=Decimal(3990), currency="ITL")
+    assert price.amount == Decimal(3990)
+    assert price.currency == "ITL"
+
+
 def test_price_post_invalid_currency():
     """Test that PricePost rejects unsupported currency codes."""
     with pytest.raises(ValidationError):
-        PricePost(amount=Decimal("3.99"), currency="EUR")
+        PricePost(amount=Decimal("3.99"), currency="JPY")
 
 
 def test_price_post_missing_fields():

--- a/tests/test_publishers.py
+++ b/tests/test_publishers.py
@@ -35,6 +35,33 @@ def test_known_publishers() -> None:
     assert marvel.resource_url.__str__() == "https://metron.cloud/publisher/marvel/"
 
 
+def test_publisher_with_alt_names() -> None:
+    """Test publisher with alternative names."""
+    publisher = Publisher(
+        id=2,
+        name="Bongo Comics",
+        country="US",
+        desc="Bongo Comics.",
+        alt_names=["Bongo Comics Group"],
+        modified="2019-06-23T15:13:19.432378-04:00",
+        resource_url="https://metron.cloud/publisher/bongo-comics/",
+    )
+    assert publisher.alt_names == ["Bongo Comics Group"]
+
+
+def test_publisher_without_alt_names() -> None:
+    """Test that alt_names defaults to an empty list when absent."""
+    marvel = Publisher(
+        id=1,
+        name="Marvel",
+        country="US",
+        desc="Marvel Comics.",
+        modified="2019-06-23T15:13:19.432378-04:00",
+        resource_url="https://metron.cloud/publisher/marvel/",
+    )
+    assert marvel.alt_names == []
+
+
 def test_publisher_list(talker: Session) -> None:
     """Test the PublishersList."""
     data = {

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -309,6 +309,27 @@ def test_series_without_alt_names() -> None:
     assert death.alt_names == []
 
 
+def test_series_with_language() -> None:
+    """Test series with a language code."""
+    series = Series(
+        **{
+            **_FULL_SERIES,
+            "id": 5000,
+            "name": "Topolino",
+            "sort_name": "Topolino",
+            "language": "it",
+            "resource_url": "https://metron.cloud/series/topolino/",
+        }
+    )
+    assert series.language == "it"
+
+
+def test_series_without_language() -> None:
+    """Test that language defaults to an empty string when absent."""
+    death = Series(**_FULL_SERIES)
+    assert death.language == ""
+
+
 def test_series_list_without_year_end() -> None:
     """Test that year_end is None when absent from a series list entry."""
     series = BaseSeries(


### PR DESCRIPTION
## Summary

Mirrors [Metron PR #599](https://github.com/Metron-Project/metron/pull/599), which adds initial support for Italian comics on the server side.

- `Publisher.alt_names` / `PublisherPost.alt_names` — array of alternative publisher names (mirrors `Series.alt_names`)
- `Series.language` / `SeriesPost.language` — ISO 639-1 language code
- `IssueSeries.language` — language code exposed on the nested `series` object of an `Issue`
- `PricePost.currency` — widened from `Literal["USD", "GBP"]` to include `EUR` and `ITL`, matching the server's expanded `CURRENCIES` setting