### PR TITLE
Track Metron's X-Cache header via Session.last_cache_status

### DIFF
--- a/mokkari/session.py
+++ b/mokkari/session.py
@@ -86,6 +86,10 @@ HEADER_SUSTAINED_LIMIT: Final[str] = "X-RateLimit-Sustained-Limit"
 HEADER_SUSTAINED_REMAINING: Final[str] = "X-RateLimit-Sustained-Remaining"
 HEADER_SUSTAINED_RESET: Final[str] = "X-RateLimit-Sustained-Reset"
 
+# Reports whether the most recent response was served from Metron's cache
+# ("HIT") or generated fresh ("MISS").
+HEADER_CACHE: Final[str] = "X-Cache"
+
 
 @dataclass(frozen=True)
 class RateLimitWindow:
@@ -244,6 +248,9 @@ class Session:
         cache (SqliteCache | None): The cache instance if provided.
         rate_limit_status (RateLimitStatus): The most recently observed rate-limit
             state, parsed from Metron's response headers.
+        last_cache_status (str | None): The ``X-Cache`` value ("HIT" or "MISS")
+            from the most recently completed response, or ``None`` if that
+            endpoint isn't cached and so didn't report one.
 
     Examples:
         Basic usage:
@@ -306,6 +313,11 @@ class Session:
         >>> issue = session.issue(1)
         >>> status = session.rate_limit_status
         >>> print(f"Sustained remaining: {status.sustained.remaining}/{status.sustained.limit}")
+
+        Checking whether the last response was served from Metron's cache:
+        >>> session = Session("username", "password")
+        >>> issue = session.issue(1)
+        >>> print(session.last_cache_status)  # "HIT" or "MISS"
 
     Raises:
         AuthenticationError: If neither an api_token nor a complete username/passwd
@@ -379,6 +391,8 @@ class Session:
         self.cache = cache
         self._rate_limit_lock = threading.Lock()
         self._rate_limit_status = RateLimitStatus()
+        self._cache_status_lock = threading.Lock()
+        self._last_cache_status: str | None = None
 
     @property
     def rate_limit_status(self) -> RateLimitStatus:
@@ -390,6 +404,21 @@ class Session:
         """
         with self._rate_limit_lock:
             return self._rate_limit_status
+
+    @property
+    def last_cache_status(self) -> str | None:
+        """Return the ``X-Cache`` value from the most recent response, if any.
+
+        Metron reports whether a response was served from its cache (``"HIT"``)
+        or generated fresh (``"MISS"``) via the ``X-Cache`` header, but only on
+        endpoints that are actually cached — others omit the header entirely.
+        This is ``None`` until the first request completes, and also resets to
+        ``None`` after any request whose endpoint isn't cached, so it always
+        reflects only the most recently completed request rather than a stale
+        value from an earlier, cached one.
+        """
+        with self._cache_status_lock:
+            return self._last_cache_status
 
     def _get(
         self,
@@ -2106,6 +2135,7 @@ class Session:
             raise exceptions.ApiError(msg) from err
 
         self._update_rate_limit_status(response.headers)
+        self._update_cache_status(response.headers)
         return response
 
     def _handle_http_response(self, response: requests.Response) -> dict[str, Any]:
@@ -2182,6 +2212,17 @@ class Session:
                 burst=burst or self._rate_limit_status.burst,
                 sustained=sustained or self._rate_limit_status.sustained,
             )
+
+    def _update_cache_status(self, headers: Any) -> None:
+        """Update the session's last-observed ``X-Cache`` status from response headers.
+
+        Unlike rate-limit headers, ``X-Cache`` is per-endpoint: Metron only adds it
+        on the paths that actually go through its response cache and omits it
+        entirely elsewhere. So a missing header resets the status to ``None``
+        rather than preserving a stale value from a previous, cached endpoint.
+        """
+        with self._cache_status_lock:
+            self._last_cache_status = headers.get(HEADER_CACHE)
 
     @staticmethod
     def _seconds_until_window_resets(window: RateLimitWindow, now: datetime) -> float:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2302,6 +2302,32 @@ def test_update_rate_limit_status_ignores_response_without_headers(session: Sess
     assert session.rate_limit_status.burst.limit == 20
 
 
+def test_last_cache_status_defaults_to_none(session: Session) -> None:
+    """A fresh session has no observed cache status until a request completes."""
+    assert session.last_cache_status is None
+
+
+def test_update_cache_status_parses_header(session: Session) -> None:
+    """The X-Cache header is captured into the session's last-observed cache status."""
+    session._update_cache_status({"X-Cache": "HIT"})
+
+    assert session.last_cache_status == "HIT"
+
+
+def test_update_cache_status_resets_when_header_absent(session: Session) -> None:
+    """A response missing the X-Cache header means that endpoint isn't cached.
+
+    Unlike rate-limit headers, X-Cache is per-endpoint (Metron only adds it on
+    cached paths), so a missing header should reset the status to None rather
+    than keep showing a stale HIT/MISS from an earlier, cached endpoint.
+    """
+    session._update_cache_status({"X-Cache": "HIT"})
+
+    session._update_cache_status({})
+
+    assert session.last_cache_status is None
+
+
 def test_check_rate_limit_allows_request_when_no_state_observed(session: Session) -> None:
     """Nothing is known yet, so the first request is never pre-emptively blocked."""
     session._check_rate_limit()  # should not raise
@@ -2431,6 +2457,52 @@ def test_request_data_updates_rate_limit_status_from_response(
     assert result == {"id": 1, "name": "Test"}
     assert session.rate_limit_status.burst.remaining == 18
     assert session.rate_limit_status.sustained.remaining == 4998
+
+
+def test_request_data_updates_cache_status_from_response(session: Session, monkeypatch) -> None:
+    """A successful response's X-Cache header should update the session's cache status."""
+
+    class DummyResp:
+        def __init__(self):
+            self.status_code = 200
+            self.headers = {"X-Cache": "MISS"}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": 1, "name": "Test"}
+
+    monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
+
+    result = session._request_data("GET", "https://test.com/api/issue/1")
+
+    assert result == {"id": 1, "name": "Test"}
+    assert session.last_cache_status == "MISS"
+
+
+def test_request_data_resets_cache_status_for_uncached_endpoint(
+    session: Session, monkeypatch
+) -> None:
+    """A subsequent request to an uncached endpoint should clear a prior HIT/MISS."""
+    session._last_cache_status = "HIT"
+
+    class DummyResp:
+        def __init__(self):
+            self.status_code = 200
+            self.headers = {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": 1, "name": "Test"}
+
+    monkeypatch.setattr("mokkari.session.requests.request", lambda *a, **k: DummyResp())
+
+    session._request_data("GET", "https://test.com/api/pull_list")
+
+    assert session.last_cache_status is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Metron now reports whether cached endpoints served a response from cache (`HIT`) or generated it fresh (`MISS`) via a new `X-Cache` response header ([Metron-Project/metron#604](https://github.com/Metron-Project/metron/commit/4ba7080460e13773ef580e1505230dfd10e37396)).
- Adds `Session.last_cache_status`, which mirrors the existing `rate_limit_status` pattern: updated from response headers after every request, thread-safe via its own lock.
- Since `X-Cache` is per-endpoint (only Metron's cached views send it — user-scoped viewsets like pull list/collection/wish list never do), a response missing the header resets the status to `None` instead of preserving a stale `HIT`/`MISS` from an earlier, cached endpoint.

